### PR TITLE
Add warning when using HTTP

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -111,5 +111,6 @@
 	"Do you really want to delete your user account?": "Do you really want to delete your user account?",
 	"This will delete your account, all notes that are owned by you and remove all references to your account from other notes.": "This will delete your account, all notes that are owned by you and remove all references to your account from other notes.",
 	"Delete user": "Delete user",
-	"Export user data": "Export user data"
+	"Export user data": "Export user data",
+	"This page is loaded using an insecure connection! Please ask your administrator to setup HTTPS.": "This page is loaded using an insecure connection! Please ask your administrator to setup HTTPS."
 }

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -232,6 +232,11 @@ body.night{
     float: right !important;
     padding: 7px 8px;
 }
+
+#http-warning {
+  margin-bottom: 0px;
+}
+
 .ui-status {
     cursor: auto !important;
     min-width: 120px;

--- a/public/js/cover.js
+++ b/public/js/cover.js
@@ -6,6 +6,8 @@ require('./locale')
 require('../css/cover.css')
 require('../css/site.css')
 
+import {checkIfHttp} from './lib/common/http'
+
 import {
     checkIfAuth,
     clearLoginState,
@@ -64,6 +66,7 @@ window.migrateHistoryFromTempCallback = pageInit
 setloginStateChangeEvent(pageInit)
 
 pageInit()
+checkIfHttp()
 
 function pageInit () {
   checkIfAuth(

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -22,6 +22,8 @@ import _ from 'lodash'
 
 import List from 'list.js'
 
+import {checkIfHttp} from './lib/common/http'
+
 import {
     checkLoginStateChanged,
     setloginStateChangeEvent
@@ -475,6 +477,9 @@ $(document).ready(function () {
   $(document).on('click', '.toggle-dropdown .dropdown-menu', function (e) {
     e.stopPropagation()
   })
+
+  // Check secure connection
+  checkIfHttp()
 })
 // when page resize
 $(window).resize(function () {

--- a/public/js/lib/common/http.js
+++ b/public/js/lib/common/http.js
@@ -1,0 +1,8 @@
+/* eslint-env browser, jquery */
+/* global Cookies */
+
+export function checkIfHttp () {
+  if (window.location.protocol === 'http:') {
+    $('#http-warning').removeClass('hidden')
+  }
+}

--- a/public/views/codimd/header.ejs
+++ b/public/views/codimd/header.ejs
@@ -178,3 +178,4 @@
     </div>
 </nav>
 <div class="ui-spinner unselectable hidden-print"></div>
+<div id="http-warning" class="alert alert-danger hidden" role="alert"><%= __('This page is loaded using an insecure connection! Please ask your administrator to setup HTTPS.') %></div>

--- a/public/views/index/body.ejs
+++ b/public/views/index/body.ejs
@@ -1,7 +1,7 @@
 <div class="site-wrapper">
     <div class="site-wrapper-inner">
         <div class="cover-container">
-
+            <div id="http-warning" class="alert alert-danger hidden" role="alert"><%= __('This page is loaded using an insecure connection! Please ask your administrator to setup HTTPS.') %></div>
             <div class="masthead clearfix">
                 <div class="inner">
                     <h3 class="masthead-brand"></h3>


### PR DESCRIPTION
We want to spread some awareness about plaintext HTTP connections. So we
show a big warning for plain HTTP connections and ask users to ask their
admin to setup HTTPS.

We may want to extent this to use link to a guide on how to do this.

Previously: https://github.com/hackmdio/codimd/pull/937