### PR TITLE
WIP: Add ratelimiting to all requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,9 @@ There are some config settings you need to change in the files below.
 | `CMD_HSTS_PRELOAD` | `true` | whether to allow preloading of the site's HSTS status (e.g. into browsers) |
 | `CMD_CSP_ENABLE` | `true` | whether to enable Content Security Policy (directives cannot be configured with environment variables) |
 | `CMD_CSP_REPORTURI` | `https://<someid>.report-uri.com/r/d/csp/enforce` | Allows to add a URL for CSP reports in case of violations |
+| `CMD_RATELIMIT_ENABLE` | `true` | Enable or disable ratelimiting for HTTP requests entirely. (Useful when you do ratelimiting on your reverse proxy) |
+| `CMD_RATELIMIT_PERSECONDS` | `60` | Time slot that is used to enforce rate-limting. |
+| `CMD_RATELIMIT_MAXREQUESTS` | `60` | Number of requests that are allowed in the time slot defined in `CMD_RATELIMIT_PERSECONDS`. |
 
 ***Note:** Due to the rename process we renamed all `HMD_`-prefix variables to be `CMD_`-prefixed. The old ones continue to work.*
 
@@ -268,6 +271,7 @@ There are some config settings you need to change in the files below.
 | `useSSL` | `true` or `false` | set to use SSL server (if `true`, will auto turn on `protocolUseSSL`) |
 | `hsts` | `{"enable": true, "maxAgeSeconds": 31536000, "includeSubdomains": true, "preload": true}` | [HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) options to use with HTTPS (default is the example value, max age is a year) |
 | `csp` | `{"enable": true, "directives": {"scriptSrc": "trustworthy-scripts.example.com"}, "upgradeInsecureRequests": "auto", "addDefaults": true}` | Configures [Content Security Policy](https://helmetjs.github.io/docs/csp/). Directives are passed to Helmet - see [their documentation](https://helmetjs.github.io/docs/csp/) for more information on the format. Some defaults are added to the configured values so that the application doesn't break. To disable this behaviour, set `addDefaults` to `false`. Further, if `usecdn` is on, some CDN locations are allowed too. By default (`auto`), insecure (HTTP) requests are upgraded to HTTPS via CSP if `useSSL` is on. To change this behaviour, set `upgradeInsecureRequests` to either `true` or `false`. |
+| `rateLimit` | `  rateLimit: { enable: true, perSeconds: 60, maxRequests: 60 }` | Adds rate-limiting to all incoming requests. Defaults are 60 requests in 60 seconds. You can modify the time span by editing `perSeconds` and the number of allowed requests within this timespan by changing the option of `maxRequests`. |
 | `protocolUseSSL` | `true` or `false` | set to use SSL protocol for resources path (only applied when domain is set) |
 | `urlAddPort` | `true` or `false` | set to add port on callback URL (ports `80` or `443` won't be applied) (only applied when domain is set) |
 | `useCDN` | `true` or `false` | set to use CDN resources or not (default is `true`) |

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ There are some config settings you need to change in the files below.
 | `CMD_PROTOCOL_USESSL` | `true` or `false` | set to use SSL protocol for resources path (only applied when domain is set) |
 | `CMD_URL_ADDPORT` | `true` or `false` | set to add port on callback URL (ports `80` or `443` won't be applied) (only applied when domain is set) |
 | `CMD_USECDN` | `true` or `false` | set to use CDN resources or not (default is `true`) |
+| `CMD_USECLOUDFLARE` | `true` or `false` | Set to true if you use Cloudflare as reverse proxy. See detailed description below. |
 | `CMD_ALLOW_ANONYMOUS` | `true` or `false` | set to allow anonymous usage (default is `true`) |
 | `CMD_ALLOW_ANONYMOUS_EDITS` | `true` or `false` | if `allowAnonymous` is `true`, allow users to select `freely` permission, allowing guests to edit existing notes (default is `false`) |
 | `CMD_ALLOW_FREEURL` | `true` or `false` | set to allow new note creation by accessing a nonexistent note URL |
@@ -275,6 +276,7 @@ There are some config settings you need to change in the files below.
 | `protocolUseSSL` | `true` or `false` | set to use SSL protocol for resources path (only applied when domain is set) |
 | `urlAddPort` | `true` or `false` | set to add port on callback URL (ports `80` or `443` won't be applied) (only applied when domain is set) |
 | `useCDN` | `true` or `false` | set to use CDN resources or not (default is `true`) |
+| `useCloudflare` | `true` or `false` | Enable this when you use [Cloudflare](https://cloudflare.com) as reverse proxy. This maps the IP information you get from Cloudflare to ratelimits etc.|
 | `allowAnonymous` | `true` or `false` | set to allow anonymous usage (default is `true`) |
 | `allowAnonymousEdits` | `true` or `false` | if `allowAnonymous` is `true`: allow users to select `freely` permission, allowing guests to edit existing notes (default is `false`) |
 | `allowFreeURL` | `true` or `false` | set to allow new note creation by accessing a nonexistent note URL |

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ var methodOverride = require('method-override')
 var cookieParser = require('cookie-parser')
 var compression = require('compression')
 var session = require('express-session')
+var RateLimit = require('express-rate-limit')
 var SequelizeStore = require('connect-session-sequelize')(session.Store)
 var fs = require('fs')
 var path = require('path')
@@ -49,6 +50,15 @@ if (config.useSSL) {
   server = require('https').createServer(options, app)
 } else {
   server = require('http').createServer(app)
+}
+
+if (config.rateLimit && config.rateLimit.enable) {
+  var limiter = new RateLimit({
+    windowMs: config.rateLimit.perSeconds * 1000, // convert to seconds
+    max: config.rateLimit.maxRequests
+  })
+
+  app.use(limiter)
 }
 
 // logger

--- a/config.json.example
+++ b/config.json.example
@@ -31,6 +31,11 @@
             "addDisqus": true,
             "addGoogleAnalytics": true
         },
+        "rateLimit": {
+          "enable": true,
+          "perSeconds": 60,
+          "maxRequests": 60
+        },
         "db": {
             "username": "",
             "password": "",

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -31,6 +31,7 @@ module.exports = {
   },
   protocolUseSSL: false,
   useCDN: true,
+  useCloudflare: false,
   allowAnonymous: true,
   allowAnonymousEdits: false,
   allowFreeURL: false,

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -24,6 +24,11 @@ module.exports = {
     upgradeInsecureRequests: 'auto',
     reportURI: undefined
   },
+  rateLimit: {
+    enable: true,
+    perSeconds: 60,
+    maxRequests: 60
+  },
   protocolUseSSL: false,
   useCDN: true,
   allowAnonymous: true,

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -20,6 +20,11 @@ module.exports = {
     enable: toBooleanConfig(process.env.CMD_CSP_ENABLE),
     reportURI: process.env.CMD_CSP_REPORTURI
   },
+  rateLimit: {
+    enable: toBooleanConfig(process.env.CMD_RATELIMIT_ENABLE),
+    perSeconds: process.env.CMD_RATELIMIT_PERSECONDS,
+    maxRequests: process.env.CMD_RATELIMIT_MAXREQUESTS
+  },
   protocolUseSSL: toBooleanConfig(process.env.CMD_PROTOCOL_USESSL),
   allowOrigin: toArrayConfig(process.env.CMD_ALLOW_ORIGIN),
   useCDN: toBooleanConfig(process.env.CMD_USECDN),

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -28,6 +28,7 @@ module.exports = {
   protocolUseSSL: toBooleanConfig(process.env.CMD_PROTOCOL_USESSL),
   allowOrigin: toArrayConfig(process.env.CMD_ALLOW_ORIGIN),
   useCDN: toBooleanConfig(process.env.CMD_USECDN),
+  useCloudflare: toBooleanConfig(process.env.CMD_USECLOUDFLARE),
   allowAnonymous: toBooleanConfig(process.env.CMD_ALLOW_ANONYMOUS),
   allowAnonymousEdits: toBooleanConfig(process.env.CMD_ALLOW_ANONYMOUS_EDITS),
   allowFreeURL: toBooleanConfig(process.env.CMD_ALLOW_FREEURL),

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bootstrap-validator": "^0.11.8",
     "chance": "^1.0.4",
     "cheerio": "^0.22.0",
+    "cloudflare-express": "^1.0.1",
     "codemirror": "git+https://github.com/hackmdio/CodeMirror.git",
     "compression": "^1.6.2",
     "connect-flash": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ejs": "^2.5.5",
     "emojify.js": "~1.1.0",
     "express": ">=4.14",
+    "express-rate-limit": "^3.2.0",
     "express-session": "^1.14.2",
     "file-saver": "^1.3.3",
     "flowchart.js": "^1.6.4",


### PR DESCRIPTION
This patch adds rate-limiting to make it harder for brute-force and DOS
attacks or similar to success.

There is some evaluation needed on what are really useful values for the
rate limiting especially when proxies and/or docker is involved.

Previously: https://github.com/hackmdio/codimd/pull/970