### PR TITLE
Integrate forkawesome with CodiMD for easier usage

### DIFF
--- a/public/docs/features.md
+++ b/public/docs/features.md
@@ -127,6 +127,12 @@ Use the syntax `[TOC]` to embed table of content into your note.
 You can type any emoji like this :smile: :smiley: :cry: :wink:
 > See full emoji list [here](http://www.emoji-cheat-sheet.com/).
 
+## Icons
+You can use any symbol from [ForkAwesome](https://forkawesome.github.io/). To use them you can either use their icon classes. As alternative use our integration: `{%fa <icon name> <icon color>%}`.
+
+{%fa rss%} {%fa lightbulb-o orange%} {%fa nextcloud #0082C9%}
+<i class="fa fa-rss" aria-hidden="true"></i> <i class="fa fa-lightbulb-o" aria-hidden="true" style="color: orange;"></i> <i class="fa fa-nextcloud" aria-hidden="true" style="color: #0082C9;"></i>
+
 ## ToDo List:
 - [ ] ToDos
   - [x] Buy some salad

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -1056,6 +1056,22 @@ md.renderer.rules.fence = (tokens, idx, options, env, self) => {
 /* Defined regex markdown it plugins */
 import Plugin from 'markdown-it-regexp'
 
+const forkawesomePlugin = new Plugin(
+    // regexp to match
+    /{%fa\s*([\d\D]*?)(\s([\d\D]*?))?\s*%}/,
+
+    (match, utils) => {
+      const iconid = match[1]
+      const color = match[3]
+      if (!iconid) return
+      const icon = $(`<i class="icon fa fa-${iconid}" aria-hidden="true"></i>`)
+      if (color) {
+        icon.attr('style', `color: ${color};`)
+      }
+      return icon[0].outerHTML
+    }
+)
+
 // youtube
 const youtubePlugin = new Plugin(
     // regexp to match
@@ -1189,6 +1205,7 @@ function metaPlugin (md) {
 }
 
 md.use(metaPlugin)
+md.use(forkawesomePlugin)
 md.use(youtubePlugin)
 md.use(vimeoPlugin)
 md.use(gistPlugin)


### PR DESCRIPTION
See commit comments for details.

Basically adds `{%fa <icon name> [<color>]%}` to use the icons instead of weird `<i>` statements.

Previous: https://github.com/hackmdio/codimd/pull/1003