### PR TITLE
Add config for toobusy middleware

### DIFF
--- a/docs/configuration-config-file.md
+++ b/docs/configuration-config-file.md
@@ -32,6 +32,7 @@ to `config.json` before filling in your own details.
 | `imageUploadType` | `imgur`, `s3`, `minio`, `azure`, `lutim` or `filesystem`(default) | Where to upload images. For S3, see our Image Upload Guides for [S3](guides/s3-image-upload.md) or [Minio](guides/minio-image-upload.md)|
 | `sourceURL` | `https://github.com/codimd/server/tree/<current commit>` | Provides the link to the source code of CodiMD on the entry page (Please, make sure you change this when you run a modified version) |
 | `staticCacheTime` | `1 * 24 * 60 * 60 * 1000` | static file cache time |
+| `tooBusyLag` | `70` | CPU time for one eventloop tick until node throttles connections. (milliseconds) |
 | `heartbeatInterval` | `5000` | socket.io heartbeat interval |
 | `heartbeatTimeout` | `10000` | socket.io heartbeat timeout |
 | `documentMaxLength` | `100000` | note max length |

--- a/docs/configuration-env-vars.md
+++ b/docs/configuration-env-vars.md
@@ -35,6 +35,7 @@ defaultNotePath can't be set from env-vars
 | `CMD_FORBIDDEN_NOTE_IDS` | `'robots.txt'` | disallow creation of notes, even if `CMD_ALLOW_FREEURL` is `true` |
 | `CMD_IMAGE_UPLOAD_TYPE` | `imgur`, `s3`, `minio`, `lutim` or `filesystem` | Where to upload images. For S3, see our Image Upload Guides for [S3](guides/s3-image-upload.md) or [Minio](guides/minio-image-upload.md), also there's a whole section on their respective env vars below. |
 | `CMD_SOURCE_URL` | `https://github.com/codimd/server/tree/<current commit>` | Provides the link to the source code of CodiMD on the entry page (Please, make sure you change this when you run a modified version) |
+| `CMD_TOOBUSY_LAG` | `70` | CPU time for one eventloop tick until node throttles connections. (milliseconds) |
 
 
 ## CodiMD Location

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -56,6 +56,8 @@ module.exports = {
   // socket.io
   heartbeatInterval: 5000,
   heartbeatTimeout: 10000,
+  // too busy timeout
+  tooBusyLag: 70,
   // document
   documentMaxLength: 100000,
   // image upload setting, available options are imgur/s3/filesystem/azure/lutim

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -33,6 +33,7 @@ module.exports = {
   dbURL: process.env.CMD_DB_URL,
   sessionSecret: process.env.CMD_SESSION_SECRET,
   sessionLife: toIntegerConfig(process.env.CMD_SESSION_LIFE),
+  tooBusyLag: toIntegerConfig(process.env.CMD_TOOBUSY_LAG),
   imageUploadType: process.env.CMD_IMAGE_UPLOAD_TYPE,
   imgur: {
     clientID: process.env.CMD_IMGUR_CLIENTID

--- a/lib/web/middleware/tooBusy.js
+++ b/lib/web/middleware/tooBusy.js
@@ -2,7 +2,11 @@
 
 const toobusy = require('toobusy-js')
 
+
 const response = require('../../response')
+const config = require('../../config')
+
+toobusy.maxLag(config.tooBusyLag)
 
 module.exports = function (req, res, next) {
   if (toobusy()) {


### PR DESCRIPTION
With very low CPU frequency or bad IO situation, as well as not-loaded
JS CodiMD happens to present unneeded "I'm busy"-messages to users.

This patch allows to configure the lag. The default is taken from the
library but set in our own default configs.

Previously: https://github.com/hackmdio/codimd/pull/1078