### PR TITLE
Use libravatar as drop-in replacement for gravatar

### DIFF
--- a/lib/letter-avatars.js
+++ b/lib/letter-avatars.js
@@ -37,7 +37,7 @@ exports.generateAvatarURL = function (name, email = '', big = true) {
   let hexDigest = hash.digest('hex')
 
   if (email !== '' && config.allowGravatar) {
-    photo = 'https://www.gravatar.com/avatar/' + hexDigest;
+    photo = 'https://cdn.libravatar.org/avatar/' + hexDigest;
     if (big) {
       photo += '?s=400'
     } else {

--- a/test/letter-avatars.js
+++ b/test/letter-avatars.js
@@ -19,8 +19,8 @@ describe('generateAvatarURL() gravatar enabled', function () {
   })
 
   it('should return correct urls', function () {
-    assert.strictEqual(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', true), 'https://www.gravatar.com/avatar/d41b5f3508cc3f31865566a47dd0336b?s=400')
-    assert.strictEqual(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', false), 'https://www.gravatar.com/avatar/d41b5f3508cc3f31865566a47dd0336b?s=96')
+    assert.strictEqual(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', true), 'https://cdn.libravatar.org/avatar/d41b5f3508cc3f31865566a47dd0336b?s=400')
+    assert.strictEqual(avatars.generateAvatarURL('Daan Sprenkels', 'hello@dsprenkels.com', false), 'https://cdn.libravatar.org/avatar/d41b5f3508cc3f31865566a47dd0336b?s=96')
   })
 
   it('should return correct urls for names with spaces', function () {


### PR DESCRIPTION
Since libravatar got a default fallback to Gravatar and in generell
allows federated image hosting for avatars this shouldn't break any
existing implementations.

The federation functionality is not added yet. This would require to use
the libravatar library.

Details:
https://wiki.libravatar.org/api/

Previously: https://github.com/hackmdio/codimd/pull/1171