### PR TITLE
cleanup of the heroku configuration

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,10 +11,6 @@
     "logo": "https://github.com/codimd/server/raw/master/public/codimd-icon-1024.png",
     "success_url": "/",
     "env": {
-        "BUILD_ASSETS": {
-            "description": "Our build script variable",
-            "value": "true"
-        },
         "NPM_CONFIG_PRODUCTION": {
             "description": "Let npm also install development build tool",
             "value": "false"
@@ -23,137 +19,129 @@
             "description": "Specify database type. See sequelize available databases. Default using postgres",
             "value": "postgres"
         },
-        "HMD_SESSION_SECRET": {
+        "CMD_SESSION_SECRET": {
             "description": "Secret used to secure session cookies.",
             "required": false
         },
-        "HMD_HSTS_ENABLE": {
+        "CMD_HSTS_ENABLE": {
             "description": "whether to also use HSTS if HTTPS is enabled",
             "required": false
         },
-        "HMD_HSTS_MAX_AGE": {
+        "CMD_HSTS_MAX_AGE": {
             "description": "max duration, in seconds, to tell clients to keep HSTS status",
             "required": false
         },
-        "HMD_HSTS_INCLUDE_SUBDOMAINS": {
+        "CMD_HSTS_INCLUDE_SUBDOMAINS": {
             "description": "whether to tell clients to also regard subdomains as HSTS hosts",
             "required": false
         },
-        "HMD_HSTS_PRELOAD": {
+        "CMD_HSTS_PRELOAD": {
             "description": "whether to allow at all adding of the site to HSTS preloads (e.g. in browsers)",
             "required": false
         },
-        "HMD_DOMAIN": {
+        "CMD_DOMAIN": {
             "description": "domain name",
             "required": false
         },
-        "HMD_URL_PATH": {
+        "CMD_URL_PATH": {
             "description": "sub url path, like `www.example.com/<URL_PATH>`",
             "required": false
         },
-        "HMD_ALLOW_ORIGIN": {
+        "CMD_ALLOW_ORIGIN": {
             "description": "domain name whitelist (use comma to separate)",
             "required": false,
             "value": "localhost"
         },
-        "HMD_PROTOCOL_USESSL": {
+        "CMD_PROTOCOL_USESSL": {
             "description": "set to use ssl protocol for resources path (only applied when domain is set)",
             "required": false
         },
-        "HMD_URL_ADDPORT": {
+        "CMD_URL_ADDPORT": {
             "description": "set to add port on callback url (port 80 or 443 won't applied) (only applied when domain is set)",
             "required": false
         },
-        "HMD_FACEBOOK_CLIENTID": {
+        "CMD_FACEBOOK_CLIENTID": {
             "description": "Facebook API client id",
             "required": false
         },
-        "HMD_FACEBOOK_CLIENTSECRET": {
+        "CMD_FACEBOOK_CLIENTSECRET": {
             "description": "Facebook API client secret",
             "required": false
         },
-        "HMD_TWITTER_CONSUMERKEY": {
+        "CMD_TWITTER_CONSUMERKEY": {
             "description": "Twitter API consumer key",
             "required": false
         },
-        "HMD_TWITTER_CONSUMERSECRET": {
+        "CMD_TWITTER_CONSUMERSECRET": {
             "description": "Twitter API consumer secret",
             "required": false
         },
-        "HMD_GITHUB_CLIENTID": {
+        "CMD_GITHUB_CLIENTID": {
             "description": "GitHub API client id",
             "required": false
         },
-        "HMD_GITHUB_CLIENTSECRET": {
+        "CMD_GITHUB_CLIENTSECRET": {
             "description": "GitHub API client secret",
             "required": false
         },
-        "HMD_GITLAB_BASEURL": {
+        "CMD_GITLAB_BASEURL": {
             "description": "GitLab authentication endpoint, set to use other endpoint than GitLab.com (optional)",
             "required": false
         },
-        "HMD_GITLAB_CLIENTID": {
+        "CMD_GITLAB_CLIENTID": {
             "description": "GitLab API client id",
             "required": false
         },
-        "HMD_GITLAB_CLIENTSECRET": {
+        "CMD_GITLAB_CLIENTSECRET": {
             "description": "GitLab API client secret",
             "required": false
         },
-        "HMD_GITLAB_SCOPE": {
+        "CMD_GITLAB_SCOPE": {
             "description": "GitLab API client scope (optional)",
             "required": false
         },
-        "HMD_MATTERMOST_BASEURL": {
+        "CMD_MATTERMOST_BASEURL": {
             "description": "Mattermost authentication endpoint",
             "required": false
         },
-        "HMD_MATTERMOST_CLIENTID": {
+        "CMD_MATTERMOST_CLIENTID": {
             "description": "Mattermost API client id",
             "required": false
         },
-        "HMD_MATTERMOST_CLIENTSECRET": {
+        "CMD_MATTERMOST_CLIENTSECRET": {
             "description": "Mattermost API client secret",
             "required": false
         },
-        "HMD_DROPBOX_CLIENTID": {
+        "CMD_DROPBOX_CLIENTID": {
             "description": "Dropbox API client id",
             "required": false
         },
-        "HMD_DROPBOX_CLIENTSECRET": {
+        "CMD_DROPBOX_CLIENTSECRET": {
             "description": "Dropbox API client secret",
             "required": false
         },
-        "HMD_DROPBOX_APP_KEY": {
+        "CMD_DROPBOX_APP_KEY": {
             "description": "Dropbox app key (for import/export)",
             "required": false
         },
-        "HMD_GOOGLE_CLIENTID": {
+        "CMD_GOOGLE_CLIENTID": {
             "description": "Google API client id",
             "required": false
         },
-        "HMD_GOOGLE_CLIENTSECRET": {
+        "CMD_GOOGLE_CLIENTSECRET": {
             "description": "Google API client secret",
             "required": false
         },
-        "HMD_IMGUR_CLIENTID": {
+        "CMD_IMGUR_CLIENTID": {
             "description": "Imgur API client id",
             "required": false
         },
-        "HMD_ALLOW_PDF_EXPORT": {
+        "CMD_ALLOW_PDF_EXPORT": {
             "description": "Enable or disable PDF exports",
             "required": false
         }
     },
     "addons": [
         "heroku-postgresql"
-    ],
-    "buildpacks": [
-        {
-            "url": "https://github.com/alex88/heroku-buildpack-vips"
-        },
-        {
-            "url": "https://github.com/heroku/heroku-buildpack-nodejs"
-        }
     ]
 }

--- a/bin/heroku
+++ b/bin/heroku
@@ -2,9 +2,7 @@
 
 set -e
 
-if [ "$BUILD_ASSETS" = true ]; then
-  # setup config files
-  cat << EOF > .sequelizerc
+cat << EOF > .sequelizerc
 var path = require('path');
 
 module.exports = {
@@ -17,7 +15,7 @@ module.exports = {
 
 EOF
 
-    cat << EOF > config.json
+cat << EOF > config.json
 
 {
   "production": {
@@ -25,7 +23,3 @@ EOF
 }
 
 EOF
-
-  # build app
-  npm run build
-fi

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "jsonlint": "find . -not -path './node_modules/*' -type f -name '*.json' -o -type f -name '*.json.example' | while read json; do echo $json ; jq . $json; done",
     "standard": "echo 'standard is no longer being used, use `npm run eslint` instead!' && exit 1",
     "dev": "webpack --config webpack.dev.js --progress --colors --watch",
+    "heroku-prebuild": "bin/heroku",
     "build": "webpack --config webpack.prod.js --progress --colors --bail",
-    "postinstall": "bin/heroku",
     "start": "sequelize db:migrate && node app.js",
     "doctoc": "doctoc --title='# Table of Contents' README.md"
   },


### PR DESCRIPTION
this removes the general `postinstall` call to `bin/heroku` and instead puts it into a heroku-prebuild hook. At the same time, env vars get updated to use the `CMD` prefix. The configured buildpacks were not used. Finally, npm run build is now automatically done by Heroku.