### PR TITLE
Fix LICENSE content

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -629,8 +629,15 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    CodiMD - Realtime collaborative markdown notes on all platforms.
+    Copyright (C) 2019  Christoph (Sheogorath) Kern
+    Copyright (C) 2019  Claudius Coenen
+    Copyright (C) 2019  Max Wu
+    Copyright (C) 2017  Yukai Huang
+    And more can be found on https://github.com/codimd/server/graphs/contributors
+    Or in the local AUTHORS file
+
+
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published by


### PR DESCRIPTION
It seems like the license was never correctly filled.

This patch updates the LICENSE file to represent members of the 
community and major code contributors.