### PR TITLE
Refactoring highlight code

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -1,9 +1,7 @@
 /* eslint-env browser, jquery */
 /* global moment, serverurl */
 
-import hljs       from 'highlight.js'
 import PDFObject  from 'pdfobject'
-import S          from 'string'
 import { saveAs } from 'file-saver'
 
 require('./lib/common/login')
@@ -149,7 +147,7 @@ export function renderTags (view) {
 
 function slugifyWithUTF8 (text) {
   // remove html tags and trim spaces
-  let newText = S(text).trim().stripTags().s
+  let newText = text.trim().replace(/<\/?[^>]+(>|$)/g, "")
   // replace all spaces in between to dashes
   newText = newText.replace(/\s+/g, '-')
   // slugify string to make it valid for attribute
@@ -469,29 +467,6 @@ export function finishView (view) {
               })
             })
     // syntax highlighting
-  view.find('code.raw').removeClass('raw')
-        .each((key, value) => {
-          const langDiv = $(value)
-          if (langDiv.length > 0) {
-            const reallang = langDiv[0].className.replace(/hljs|wrap/g, '').trim()
-            const codeDiv = langDiv.find('.code')
-            let code = ''
-            if (codeDiv.length > 0) code = codeDiv.html()
-            else code = langDiv.html()
-            var result
-            if (!reallang) {
-              result = {
-                value: code
-              }
-            } else {
-              result = {
-                value: highlight.render(code, reallang)
-              }
-            }
-            if (codeDiv.length > 0) codeDiv.html(result.value)
-            else langDiv.html(result.value)
-          }
-        })
     // mathjax
   const mathjaxdivs = view.find('span.mathjax.raw').removeClass('raw').toArray()
   try {
@@ -873,40 +848,6 @@ export function scrollToHash () {
   location.hash = hash
 }
 
-function highlightRender (code, lang) {
-  if (!lang || /no(-?)highlight|plain|text/.test(lang)) { return }
-  code = S(code).escapeHTML().s
-  if (lang === 'sequence') {
-    return `<div class="sequence-diagram raw">${code}</div>`
-  } else if (lang === 'flow') {
-    return `<div class="flow-chart raw">${code}</div>`
-  } else if (lang === 'graphviz') {
-    return `<div class="graphviz raw">${code}</div>`
-  } else if (lang === 'mermaid') {
-    return `<div class="mermaid raw">${code}</div>`
-  } else if (lang === 'abc') {
-    return `<div class="abc raw">${code}</div>`
-  }
-  const result = {
-    value: code
-  }
-  const showlinenumbers = /=$|=\d+$|=\+$/.test(lang)
-  if (showlinenumbers) {
-    let startnumber = 1
-    const matches = lang.match(/=(\d+)$/)
-    if (matches) { startnumber = parseInt(matches[1]) }
-    const lines = result.value.split('\n')
-    const linenumbers = []
-    for (let i = 0; i < lines.length - 1; i++) {
-      linenumbers[i] = `<span data-linenumber='${startnumber + i}'></span>`
-    }
-    const continuelinenumber = /=\+$/.test(lang)
-    const linegutter = `<div class='gutter linenumber${continuelinenumber ? ' continue' : ''}'>${linenumbers.join('\n')}</div>`
-    result.value = `<div class='wrapper'>${linegutter}<div class='code'>${result.value}</div></div>`
-  }
-  return result.value
-}
-
 import markdownit from 'markdown-it'
 import markdownitContainer from 'markdown-it-container'
 
@@ -916,7 +857,7 @@ export let md = markdownit('default', {
   langPrefix: '',
   linkify: true,
   typographer: true,
-  highlight: highlightRender
+  highlight: highlight.render
 })
 window.md = md
 

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -1,19 +1,9 @@
 /* eslint-env browser, jquery */
 /* global moment, serverurl */
 
-require('prismjs/themes/prism.css')
-require('prismjs/components/prism-wiki')
-require('prismjs/components/prism-haskell')
-require('prismjs/components/prism-go')
-require('prismjs/components/prism-typescript')
-require('prismjs/components/prism-jsx')
-require('prismjs/components/prism-makefile')
-require('prismjs/components/prism-gherkin')
-
-import Prism from 'prismjs'
-import hljs from 'highlight.js'
-import PDFObject from 'pdfobject'
-import S from 'string'
+import hljs       from 'highlight.js'
+import PDFObject  from 'pdfobject'
+import S          from 'string'
 import { saveAs } from 'file-saver'
 
 require('./lib/common/login')
@@ -21,6 +11,8 @@ require('../vendor/md-toc')
 var Viz = require('viz.js')
 
 import getUIElements from './lib/editor/ui-elements'
+import highlight     from './lib/highlight'
+
 const ui = getUIElements()
 
 // auto update last change
@@ -491,30 +483,9 @@ export function finishView (view) {
               result = {
                 value: code
               }
-            } else if (reallang === 'haskell' || reallang === 'go' || reallang === 'typescript' || reallang === 'jsx' || reallang === 'gherkin') {
-              code = S(code).unescapeHTML().s
-              result = {
-                value: Prism.highlight(code, Prism.languages[reallang])
-              }
-            } else if (reallang === 'tiddlywiki' || reallang === 'mediawiki') {
-              code = S(code).unescapeHTML().s
-              result = {
-                value: Prism.highlight(code, Prism.languages.wiki)
-              }
-            } else if (reallang === 'cmake') {
-              code = S(code).unescapeHTML().s
-              result = {
-                value: Prism.highlight(code, Prism.languages.makefile)
-              }
             } else {
-              const languages = hljs.listLanguages()
-              if (languages.includes(reallang)) {
-                code = S(code).unescapeHTML().s
-                result = hljs.highlight(reallang, code)
-              } else {
-                result = {
-                  value: code
-                }
+              result = {
+                value: highlight.render(code, reallang)
               }
             }
             if (codeDiv.length > 0) codeDiv.html(result.value)

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -507,12 +507,14 @@ export function finishView (view) {
                 value: Prism.highlight(code, Prism.languages.makefile)
               }
             } else {
-              code = S(code).unescapeHTML().s
               const languages = hljs.listLanguages()
-              if (!languages.includes(reallang)) {
-                result = hljs.highlightAuto(code)
-              } else {
+              if (languages.includes(reallang)) {
+                code = S(code).unescapeHTML().s
                 result = hljs.highlight(reallang, code)
+              } else {
+                result = {
+                  value: code
+                }
               }
             }
             if (codeDiv.length > 0) codeDiv.html(result.value)

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -16,7 +16,6 @@ import TurndownService from 'turndown'
 import { saveAs } from 'file-saver'
 import randomColor from 'randomcolor'
 import store from 'store'
-import hljs from 'highlight.js'
 
 import _ from 'lodash'
 
@@ -75,6 +74,7 @@ import {
 } from './history'
 
 import { preventXSS } from './render'
+import highlight      from './lib/highlight'
 
 import Editor from './lib/editor'
 
@@ -92,7 +92,7 @@ var cursorMenuThrottle = 50
 var cursorActivityDebounce = 50
 var cursorAnimatePeriod = 100
 var supportContainers = ['success', 'info', 'warning', 'danger']
-var supportCodeModes = ['javascript', 'typescript', 'jsx', 'htmlmixed', 'htmlembedded', 'css', 'xml', 'clike', 'clojure', 'ruby', 'python', 'shell', 'php', 'sql', 'haskell', 'coffeescript', 'yaml', 'pug', 'lua', 'cmake', 'nginx', 'perl', 'sass', 'r', 'dockerfile', 'tiddlywiki', 'mediawiki', 'go', 'gherkin'].concat(hljs.listLanguages())
+var supportCodeModes = [].concat(highlight.listLanguages())
 var supportCharts = ['sequence', 'flow', 'graphviz', 'mermaid', 'abc']
 var supportHeaders = [
   {

--- a/public/js/lib/highlight/externals.js
+++ b/public/js/lib/highlight/externals.js
@@ -1,0 +1,30 @@
+'use strict';
+
+import {escapeHtml}  from './utils'
+
+let externals = {}
+
+externals.checkLang = function (lang) {
+  if (typeof lang !== 'string') {
+    return false
+  }
+  const languages = ['sequence', 'flow', 'graphviz', 'mermaid', 'abc']
+  return languages.includes(lang.toLowerCase())
+}
+
+externals.highlight = function (code, lang) {
+  const escapedCode = escapeHtml(code)
+  if (lang === 'sequence') {
+    return `<div class="sequence-diagram raw">${escapedCode}</div>`
+  } else if (lang === 'flow') {
+    return `<div class="flow-chart raw">${escapedCode}</div>`
+  } else if (lang === 'graphviz') {
+    return `<div class="graphviz raw">${escapedCode}</div>`
+  } else if (lang === 'mermaid') {
+    return `<div class="mermaid raw">${escapedCode}</div>`
+  } else if (lang === 'abc') {
+    return `<div class="abc raw">${escapedCode}</div>`
+  }
+}
+
+module.exports = externals

--- a/public/js/lib/highlight/hljs.js
+++ b/public/js/lib/highlight/hljs.js
@@ -1,0 +1,13 @@
+'use strict';
+
+import hljs  from 'highlight.js'
+
+hljs.checkLang = function (lang) {
+  if (typeof lang !== 'string') {
+    return false
+  }
+  const languages = hljs.listLanguages()
+  return languages.includes(lang.toLowerCase())
+}
+
+module.exports = hljs

--- a/public/js/lib/highlight/index.js
+++ b/public/js/lib/highlight/index.js
@@ -1,26 +1,43 @@
 'use strict';
 
-import S     from 'string'
 import hljs  from './hljs'
 import Prism from './prism'
+import externals from './externals'
+import {escapeHtml, addLineNumbers} from './utils'
 
 exports.listLanguages = function () {
   return [].concat(hljs.listLanguages()).concat(Prism.listLanguages())
 }
 
 exports.render = function (code, lang) {
-  if (typeof code !== 'string' || typeof lang !== 'string') {
-    return code
+  if (!lang || /no(-?)highlight|plain|text/.test(lang)) {
+    return
   }
+
+  const langMatch = /([^=]+)(=((\d+)|\+)?)?$/.exec(lang)
+  const language = langMatch !== null && langMatch[1] ? langMatch[1] : ''
+  const startnumber = parseInt(langMatch !== null && langMatch[2] ? langMatch[4] || 1 : -1)
+
+  if (externals.checkLang(language)) {
+    return externals.highlight(code, language)
+  }
+
+  const escapedCode = highlight(code, language)
+  if (startnumber !== -1) {
+    return `<pre class="part"><code>${addLineNumbers(escapedCode, lang, startnumber)}</code></pre>`
+  }
+  return `<pre class="part"><code>${escapedCode}</code></pre>`
+}
+
+
+function highlight (code, lang) {
   if (Prism.checkLang(lang)) {
-    code = S(code).unescapeHTML().s
     return Prism.highlight(code, Prism.selectLang(lang))
   }
 
   if (hljs.checkLang(lang)) {
-      code = S(code).unescapeHTML().s
-      return hljs.highlight(lang, code).value
-    } else {
-      return code
-    }
+    return hljs.highlight(lang, code).value
+  }
+
+  return escapeHtml(code)
 }

--- a/public/js/lib/highlight/index.js
+++ b/public/js/lib/highlight/index.js
@@ -1,0 +1,26 @@
+'use strict';
+
+import S     from 'string'
+import hljs  from './hljs'
+import Prism from './prism'
+
+exports.listLanguages = function () {
+  return [].concat(hljs.listLanguages()).concat(Prism.listLanguages())
+}
+
+exports.render = function (code, lang) {
+  if (typeof code !== 'string' || typeof lang !== 'string') {
+    return code
+  }
+  if (Prism.checkLang(lang)) {
+    code = S(code).unescapeHTML().s
+    return Prism.highlight(code, Prism.selectLang(lang))
+  }
+
+  if (hljs.checkLang(lang)) {
+      code = S(code).unescapeHTML().s
+      return hljs.highlight(lang, code).value
+    } else {
+      return code
+    }
+}

--- a/public/js/lib/highlight/prism.js
+++ b/public/js/lib/highlight/prism.js
@@ -1,0 +1,53 @@
+/* eslint-env browser, jquery */
+/* global moment, serverurl */
+
+/**
+ * WHY
+ * ---
+ * This extends the Prism.js module to provide some useful and needed functions
+ * for better integration with CodiMD.
+ * It also allows central provisioning of additional languages.
+ */
+
+require('prismjs/themes/prism.css')
+require('prismjs/components/prism-wiki')
+require('prismjs/components/prism-haskell')
+require('prismjs/components/prism-go')
+require('prismjs/components/prism-rust')
+require('prismjs/components/prism-typescript')
+require('prismjs/components/prism-jsx')
+require('prismjs/components/prism-makefile')
+require('prismjs/components/prism-gherkin')
+
+import Prism from 'prismjs'
+
+const languages = ['haskell', 'go', 'rust', 'typescript', 'typescript', 'js', 'jsx', 'gherkin', 'tiddlywiki', 'mediawiki', 'wiki', 'cmake']
+
+Prism.listLanguages = function () {
+  return languages
+}
+
+Prism.checkLang = function (lang) {
+  if (typeof lang !== 'string') {
+    return false
+  }
+  return languages.includes(lang.toLowerCase())
+}
+
+Prism.selectLang = function (lang) {
+  if (typeof lang !== 'string') {
+    return undefined
+  }
+
+  switch (lang.toLowerCase()) {
+    case "mediawiki":
+    case "tiddlywiki":
+      return Prism.languages.wiki
+    case "cmake":
+      return Prism.languages.makefile
+    default:
+      return Prism.languages[lang.toLowerCase()]
+  }
+}
+
+module.exports = Prism

--- a/public/js/lib/highlight/prism.js
+++ b/public/js/lib/highlight/prism.js
@@ -1,5 +1,4 @@
 /* eslint-env browser, jquery */
-/* global moment, serverurl */
 
 /**
  * WHY

--- a/public/js/lib/highlight/utils.js
+++ b/public/js/lib/highlight/utils.js
@@ -1,0 +1,17 @@
+export function escapeHtml (string) {
+  let element = document.createElement('div')
+  let stringElement = document.createTextNode(string)
+  element.appendChild(stringElement)
+  return element.innerHTML
+}
+
+export function addLineNumbers (escapedCode, lang, startnumber) {
+  const lines = escapedCode.split('\n')
+  const linenumbers = []
+  for (let i = 0; i < lines.length - 1; i++) {
+    linenumbers[i] = `<span data-linenumber='${startnumber + i}'></span>`
+  }
+  const continuelinenumber = /=\+$/.test(lang)
+  const linegutter = `<div class='gutter linenumber${continuelinenumber ? ' continue' : ''}'>${linenumbers.join('\n')}</div>`
+  return `<div class='wrapper'>${linegutter}<div class='code'>${escapedCode}</div></div>`
+}


### PR DESCRIPTION
Was working on this a while ago, but never open a PR. Time to change :3 This moves most of the highlight code into the rendering process of markdown-it and this way hopefully helps to make future extensions easier.

Not sure how much of a difference it makes from a performance perspective, but hopefully simplifies the control-flow for highlighting so it becomes easier to understand.