### PR TITLE
Added a configuration option for passport-saml:

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -93,6 +93,7 @@
             "idpCert": "change: certificate file path of IdP in PEM format",
             "issuer": "change or delete: identity of the service provider (default: serverurl)",
             "identifierFormat": "change or delete: name identifier format (default: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress')",
+            "disableRequestedAuthnContext": "change or delete: true to allow any authentication method, false restricts to password authentication method (default: false)",
             "groupAttribute": "change or delete: attribute name for group list (ex: memberOf)",
             "requiredGroups": [ "change or delete: group names that allowed" ],
             "externalGroups": [ "change or delete: group names that not allowed" ],

--- a/docs/configuration-env-vars.md
+++ b/docs/configuration-env-vars.md
@@ -183,6 +183,7 @@ defaultNotePath can't be set from env-vars
 | `CMD_SAML_IDPSSOURL` | `https://idp.example.com/sso` | authentication endpoint of IdP. for details, see [guide](guides/auth/saml-onelogin.md). |
 | `CMD_SAML_IDPCERT` | `/path/to/cert.pem` | certificate file path of IdP in PEM format |
 | `CMD_SAML_ISSUER` | no example | identity of the service provider (optional, default: serverurl)" |
+| `CMD_SAML_DISABLEREQUESTEDAUTHNCONTEXT` | `true` or `false` | true to allow any authentication method, false restricts to password authentication (PasswordProtectedTransport) method (default: false) |
 | `CMD_SAML_IDENTIFIERFORMAT` | no example | name identifier format (optional, default: `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`) |
 | `CMD_SAML_GROUPATTRIBUTE` | `memberOf` | attribute name for group list (optional) |
 | `CMD_SAML_REQUIREDGROUPS` | `codimd-users` | group names that allowed (use vertical bar to separate) (optional) |

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -138,6 +138,7 @@ module.exports = {
     idpCert: undefined,
     issuer: undefined,
     identifierFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+    disableRequestedAuthnContext: false,
     groupAttribute: undefined,
     externalGroups: [],
     requiredGroups: [],

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -115,6 +115,7 @@ module.exports = {
     idpCert: process.env.CMD_SAML_IDPCERT,
     issuer: process.env.CMD_SAML_ISSUER,
     identifierFormat: process.env.CMD_SAML_IDENTIFIERFORMAT,
+    disableRequestedAuthnContext: toBooleanConfig(process.env.CMD_SAML_DISABLEREQUESTEDAUTHNCONTEXT),
     groupAttribute: process.env.CMD_SAML_GROUPATTRIBUTE,
     externalGroups: toArrayConfig(process.env.CMD_SAML_EXTERNALGROUPS, '|', []),
     requiredGroups: toArrayConfig(process.env.CMD_SAML_REQUIREDGROUPS, '|', []),

--- a/lib/config/hackmdEnvironment.js
+++ b/lib/config/hackmdEnvironment.js
@@ -109,6 +109,7 @@ module.exports = {
     idpCert: process.env.HMD_SAML_IDPCERT,
     issuer: process.env.HMD_SAML_ISSUER,
     identifierFormat: process.env.HMD_SAML_IDENTIFIERFORMAT,
+    disableRequestedAuthnContext: toBooleanConfig(process.env.HMD_SAML_DISABLEREQUESTEDAUTHNCONTEXT),
     groupAttribute: process.env.HMD_SAML_GROUPATTRIBUTE,
     externalGroups: toArrayConfig(process.env.HMD_SAML_EXTERNALGROUPS, '|', []),
     requiredGroups: toArrayConfig(process.env.HMD_SAML_REQUIREDGROUPS, '|', []),

--- a/lib/web/auth/saml/index.js
+++ b/lib/web/auth/saml/index.js
@@ -17,7 +17,8 @@ passport.use(new SamlStrategy({
   entryPoint: config.saml.idpSsoUrl,
   issuer: config.saml.issuer || config.serverURL,
   cert: fs.readFileSync(config.saml.idpCert, 'utf-8'),
-  identifierFormat: config.saml.identifierFormat
+  identifierFormat: config.saml.identifierFormat,
+  disableRequestedAuthnContext: config.saml.disableRequestedAuthnContext
 }, function (user, done) {
   // check authorization if needed
   if (config.saml.externalGroups && config.saml.groupAttribute) {


### PR DESCRIPTION
(Continuing work by @nopap from https://github.com/hackmdio/codimd/pull/1097)

disableRequestedAuthnContext: true|false

By default only Password authmethod is accepted, this option allows any other method.

Issue and option described here:
https://github.com/bergie/passport-saml/issues/226