### PR TITLE
change default mode to "both" when clicking edit

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -427,7 +427,7 @@ function publishNoteActions (req, res, next) {
         actionDownload(req, res, note)
         break
       case 'edit':
-        res.redirect(config.serverURL + '/' + (note.alias ? note.alias : models.Note.encodeNoteId(note.id)))
+        res.redirect(config.serverURL + '/' + (note.alias ? note.alias : models.Note.encodeNoteId(note.id)) + '?both')
         break
       default:
         res.redirect(config.serverURL + '/s/' + note.shortid)
@@ -441,7 +441,7 @@ function publishSlideActions (req, res, next) {
     var action = req.params.action
     switch (action) {
       case 'edit':
-        res.redirect(config.serverURL + '/' + (note.alias ? note.alias : models.Note.encodeNoteId(note.id)))
+        res.redirect(config.serverURL + '/' + (note.alias ? note.alias : models.Note.encodeNoteId(note.id)) + '?both')
         break
       default:
         res.redirect(config.serverURL + '/p/' + note.shortid)


### PR DESCRIPTION
Add "both" mode to URLs because I assume most people want to straight away see the code when they click the "edit" button in a published note.

Fixes https://github.com/codimd/server/issues/27

Not tested, followed instructions from @ccoenen , please do review! :)