### PR TITLE
Fix broken dependency js-sequence-diagrams

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jquery-mousewheel": "^3.1.13",
     "jquery-ui": "^1.12.1",
     "js-cookie": "^2.1.3",
-    "js-sequence-diagrams": "^1000000.0.6",
+    "js-sequence-diagrams": "git+https://github.com/codimd/js-sequence-diagrams.git",
     "js-url": "^2.3.0",
     "js-yaml": "^3.13.1",
     "jsdom-nogyp": "^0.8.3",


### PR DESCRIPTION
A few days ago the dependency was removed from npm. this causes various
setups to fail and blocks deployments and development.

This patch should fix the dependency and allow CodiMD to move forward.

Fixes #39 