### PR TITLE
Add community forum to help section

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -112,8 +112,9 @@
 	"This will delete your account, all notes that are owned by you and remove all references to your account from other notes.": "This will delete your account, all notes that are owned by you and remove all references to your account from other notes.",
 	"Delete user": "Delete user",
 	"Export user data": "Export user data",
-	"Help us translating on %s": "Help us translating on %s",
 	"Source Code": "Source Code",
 	"Powered by %s": "Powered by %s",
-	"Register": "Register"
+	"Register": "Register",
+	"Help us translating": "Help us translating",
+	"Join the community": "Join the community"
 }

--- a/public/views/shared/help-modal.ejs
+++ b/public/views/shared/help-modal.ejs
@@ -15,11 +15,13 @@
                                 <h3 class="panel-title"><%= __('Contacts') %></h3>
                             </div>
                             <div class="panel-body">
-                                <a href="https://github.com/codimd/server/issues" target="_blank"><i class="fa fa-tag fa-fw"></i> <%= __('Report an issue') %></a>
+                                <a href="https://community.codimd.org" target="_blank"><i class="fa fa-users fa-fw"></i> <%= __('Join the community') %></a>
                                 <br>
                                 <a href="https://riot.im/app/#/room/#codimd:matrix.org" target="_blank"><i class="fa fa-hashtag fa-fw"></i> <%= __('Meet us on %s', 'Matrix') %></a>
                                 <br>
-                                <a href="https://translate.codimd.org" target="_blank"><i class="fa fa-language fa-fw"></i> <%= __('Help us translating on %s', 'POEditor') %></a>
+                                <a href="https://github.com/codimd/server/issues" target="_blank"><i class="fa fa-tag fa-fw"></i> <%= __('Report an issue') %></a>
+                                <br>
+                                <a href="https://translate.codimd.org" target="_blank"><i class="fa fa-language fa-fw"></i> <%= __('Help us translating') %></a>
                             </div>
                         </div>
                         <div class="panel panel-default">


### PR DESCRIPTION
We have a community forum and want to use it for users support and to
bring developers and end-users together. In order to achieve this, it
would be helpful to inform users about its existence.

This patch adds the community forum as resource to the help section and
aligns it along the Matrix channel and GitHub issue tracker.

Here a preview of a new contact section:

![New menu organisation](https://user-images.githubusercontent.com/8719867/55994132-36363600-5cb1-11e9-85b5-ca12a9c421ce.png)
