### PR TITLE
Replace js-url with wurl

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "jquery-ui": "^1.12.1",
     "js-cookie": "^2.1.3",
     "js-sequence-diagrams": "git+https://github.com/codimd/js-sequence-diagrams.git",
-    "js-url": "^2.3.0",
+    "wurl": "^2.5.3",
     "js-yaml": "^3.13.1",
     "jsdom-nogyp": "^0.8.3",
     "keymaster": "^1.6.2",

--- a/public/js/history.js
+++ b/public/js/history.js
@@ -4,6 +4,7 @@
 import store from 'store'
 import S from 'string'
 import LZString from 'lz-string'
+import url from 'wurl'
 
 import {
   checkNoteIdValid,
@@ -23,9 +24,9 @@ window.migrateHistoryFromTempCallback = null
 migrateHistoryFromTemp()
 
 function migrateHistoryFromTemp () {
-  if (window.url('#tempid')) {
+  if (url('#tempid')) {
     $.get(`${serverurl}/temp`, {
-      tempid: window.url('#tempid')
+      tempid: url('#tempid')
     })
     .done(data => {
       if (data && data.temp) {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -17,6 +17,7 @@ import { saveAs } from 'file-saver'
 import randomColor from 'randomcolor'
 import store from 'store'
 import hljs from 'highlight.js'
+import url from 'wurl'
 
 import _ from 'lodash'
 
@@ -1373,12 +1374,12 @@ $('#gistImportModalConfirm').click(function () {
   if (!isValidURL(gisturl)) {
     showMessageModal('<i class="fa fa-github"></i> Import from Gist', 'Not a valid URL :(', '', '', false)
   } else {
-    var hostname = window.url('hostname', gisturl)
+    var hostname = url('hostname', gisturl)
     if (hostname !== 'gist.github.com') {
       showMessageModal('<i class="fa fa-github"></i> Import from Gist', 'Not a valid Gist URL :(', '', '', false)
     } else {
       ui.spinner.show()
-      $.get('https://api.github.com/gists/' + window.url('-1', gisturl))
+      $.get('https://api.github.com/gists/' + url('-1', gisturl))
                 .done(function (data) {
                   if (data.files) {
                     var contents = ''

--- a/public/views/index/foot.ejs
+++ b/public/views/index/foot.ejs
@@ -5,7 +5,6 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/list.pagination.js/0.1.1/list.pagination.min.js" integrity="sha256-WwTza96H3BgcQTfEfxX7MFaFc/dZA0QrPRKDRLdFHJo=" crossorigin="anonymous" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/3.5.2/select2.min.js" integrity="sha256-HzzZFiY4t0PIv02Tm8/R3CVvLpcjHhO1z/YAUCp4oQ4=" crossorigin="anonymous" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.17.1/moment-with-locales.min.js" integrity="sha256-vvT7Ok9u6GbfnBPXnbM6FVDEO8E1kTdgHOFZOAXrktA=" crossorigin="anonymous" defer></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/js-url/2.3.0/url.min.js" integrity="sha256-HOZJz4x+1mn1Si84WT5XKXPtOlTytmZLnMb6n1v4+5Q=" crossorigin="anonymous" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/1000hz-bootstrap-validator/0.11.8/validator.min.js" integrity="sha256-LHeY7YoYJ0SSXbCx7sR14Pqna+52moaH3bhv0Mjzd/M=" crossorigin="anonymous" defer></script>
 <%- include ../build/cover-scripts %>
 <% } else { %>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -195,13 +195,11 @@ module.exports = {
       'bootstrap-validator',
       'expose-loader?select2!select2',
       'expose-loader?moment!moment',
-      'script-loader!js-url',
       path.join(__dirname, 'public/js/cover.js')
     ],
     index: [
       'babel-polyfill',
       'script-loader!jquery-ui-resizable',
-      'script-loader!js-url',
       'script-loader!Idle.Js',
       'expose-loader?LZString!lz-string',
       'script-loader!codemirror',
@@ -248,7 +246,6 @@ module.exports = {
       'expose-loader?jsyaml!js-yaml',
       'script-loader!mermaid',
       'expose-loader?moment!moment',
-      'script-loader!js-url',
       'script-loader!handlebars',
       'expose-loader?hljs!highlight.js',
       'expose-loader?emojify!emojify.js',


### PR DESCRIPTION
js-url is outdated and wurl is it's successor. This will fix some possible
vulnerabilities in the dependencies and also optimize the build process 
by removing the external library toward internal tooling.