### PR TITLE
Add name of directory to clone into

### DIFF
--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -16,7 +16,7 @@ CodiMD by docker container
 The easiest way to setup CodiMD using docker are using the following three commands:
 
 ```sh
-git clone https://github.com/codimd/container.git
+git clone https://github.com/codimd/container.git codimd-container
 cd codimd-container
 docker-compose up
 ```


### PR DESCRIPTION
The docker setup instructions, on the `git clone` step, are missing the name of the directory to clone into that is used in the next step: `cd codimd-container`.