### PR TITLE
WIP drop node 6 support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     ["env", {
       "targets": {
-        "node": "6",
+        "node": "8",
         "uglify": true
       }
     }]

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,10 @@ cache: yarn
 env:
   global:
     - CXX=g++-4.8
-    - YARN_VERSION=1.15.2
+    - YARN_VERSION=1.16.0
 
 jobs:
   include:
-    - env: task=npm-test
-      node_js:
-        - 6
-      before_install:
-        - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version "$YARN_VERSION"
-        - export PATH="$HOME/.yarn/bin:$PATH"
     - env: task=npm-test
       node_js:
         - 8
@@ -23,6 +17,12 @@ jobs:
     - env: task=npm-test
       node_js:
         - 10
+      before_install:
+        - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version "$YARN_VERSION"
+        - export PATH="$HOME/.yarn/bin:$PATH"
+    - env: task=npm-test
+      node_js:
+        - 12
       before_install:
         - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version "$YARN_VERSION"
         - export PATH="$HOME/.yarn/bin:$PATH"

--- a/docs/setup/manual-setup.md
+++ b/docs/setup/manual-setup.md
@@ -3,7 +3,7 @@ Manual Installation
 
 ## Requirements on your server
 
-- Node.js 6.x or up (test up to 7.5.0) and <10.x
+- Node.js 8.x or up
 - Database (PostgreSQL, MySQL, MariaDB, SQLite, MSSQL) use charset `utf8`
 - npm (and its dependencies, [node-gyp](https://github.com/nodejs/node-gyp#installation))
 - yarn

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "**/request": "^2.88.0"
   },
   "engines": {
-    "node": ">=6.x"
+    "node": ">=8.x"
   },
   "bugs": "https://github.com/codimd/server/issues",
   "keywords": [


### PR DESCRIPTION
We will no longer test on node6 and instead focus on 8+. This won't break node6 immediately, but we will no longer go out of our way supporting a version that does not receive security updates.

Has been discussed and started in https://github.com/hackmdio/codimd/pull/1120