### PR TITLE
Fix hidden header on link

### DIFF
--- a/public/css/extra.css
+++ b/public/css/extra.css
@@ -384,6 +384,14 @@ small .dropdown a:focus, small .dropdown a:hover {
     color: #eee;
 }
 
+*[id]:before {
+  display: block;
+  content: " ";
+  margin-top: -55px;
+  height: 55px;
+  visibility: hidden;
+}
+
 @media print {
     div, table, img, pre, blockquote {
         page-break-inside: avoid !important;


### PR DESCRIPTION
When people link a section or use the ToC to scroll to it upwards, it
happens that those become hidden behind the navbar.

This patch adds a little hack from StackOverflow[1] in order to fix this
problem. By adding a pseudo element in front of any field that contains
an id, it's possible to add the needed space.

There was no negative impact found except of marking around the header
areas in the rendered view requires a bit preciser work. This needs some
more detailed testing.

[1]: https://stackoverflow.com/a/24298427

Fixes #76 