### PR TITLE
Fix CodeMirror toolbar hiding content

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -106,7 +106,10 @@ body.night{
     color: #78B2F2 !important;
 }
 .CodeMirror-sizer {
-    margin-bottom: 0px !important;
+    /* Make sure CodeMirror doesn't hide text under the status bar
+     * 26px is the height of the status bar.
+     */
+    margin-bottom: 26px !important;
 }
 .CodeMirror-insert-match {
   background: lawngreen;


### PR DESCRIPTION
As it may happens that the codemirror content flows underneath the
status bar, this patch should help to avoid it. It adds the size of the
status bar as margin-bottom so the codemirror window itself is forced
above the statusbar.

Fixes #80 