### PR TITLE
Fix missing pictures for OpenID

### DIFF
--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -141,6 +141,9 @@ module.exports = function (sequelize, DataTypes) {
           case 'saml':
             photo = generateAvatarURL(profile.username, profile.emails[0], bigger)
             break
+          default:
+            photo = generateAvatarURL(profile.username)
+            break
         }
         return photo
       },


### PR DESCRIPTION
Currently a problem appears when using OpenID for authentication as
there is no method to add a profile picture right now.

This patch makes sure that all undefined login methods get a profile
picture.

Fixes #36 