### PR TITLE
fixed styling of slides preview

### DIFF
--- a/public/css/slide-preview.css
+++ b/public/css/slide-preview.css
@@ -56,3 +56,64 @@
   height: 1.5em;
   border: 3px solid #777;
 }
+
+.markdown-body.slides aside.notes {
+  display: none;
+}
+
+.markdown-body.slides ul, .markdown-body.slides ol {
+  display: inline-block;
+  text-align: left;
+  margin: 0 0 0 1em;
+  padding: 0;
+}
+
+.markdown-body.slides table {
+  width: 50%;
+  margin: 0 auto;
+  border-collapse: collapse;
+  border-spacing: 0;
+  display: table;
+}
+
+.markdown-body.slides table th, .markdown-body.slides table td {
+  text-align: left;
+  padding: 0.2em 0.5em 0.2em 0.5em;
+  border:none;
+  border-bottom: 1px solid;
+}
+
+.markdown-body.slides table tr {
+  border-top: 0;
+  background-color: #fff;
+}
+
+.markdown-body.slides table tr:nth-child(2n) {
+  background-color: inherit;
+}
+
+.markdown-body.slides table tbody tr:last-child th, .markdown-body.slides table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.markdown-body.slides h1, .markdown-body.slides h2 {
+    border-bottom: 0;
+}
+
+.night .markdown-body.slides h1,
+.night .markdown-body.slides h2,
+.night .markdown-body.slides h3,
+.night .markdown-body.slides h4,
+.night .markdown-body.slides h5,
+.night .markdown-body.slides h6 {
+    color: black;
+}
+
+.markdown-body section > section:last-child {
+	margin-bottom: 1.5em !important;
+}
+
+/* slides previews get a black background, controlled by js */
+.ui-view-area.black {
+  background-color: black !important;;
+}

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -2740,6 +2740,7 @@ function updateViewInner () {
   delete md.metaError
   var rendered = md.render(value)
   if (md.meta.type && md.meta.type === 'slide') {
+    ui.area.view.addClass('black')
     var slideOptions = {
       separator: '^(\r\n?|\n)---(\r\n?|\n)$',
       verticalSeparator: '^(\r\n?|\n)----(\r\n?|\n)$'
@@ -2756,6 +2757,7 @@ function updateViewInner () {
     if (lastMeta.type && lastMeta.type === 'slide') {
       refreshView()
       ui.area.markdown.removeClass('slides')
+      ui.area.view.removeClass('black')
       appState.syncscroll = true
       checkSyncToggle()
     }


### PR DESCRIPTION
As per #79: 

- improved the styling of lists, tables and headings for slides previews.
- made the background of slides preview black, regardless of the day/night mode
 
Signed-off-by: Toma Tasovac <ttasovac@humanistika.org>