### PR TITLE
Update app.js - HSTS Syntax Update

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,7 +84,7 @@ app.use(compression())
 if (config.hsts.enable) {
   app.use(helmet.hsts({
     maxAge: config.hsts.maxAgeSeconds,
-    includeSubdomains: config.hsts.includeSubdomains,
+    includeSubDomains: config.hsts.includeSubDomains,
     preload: config.hsts.preload
   }))
 } else if (config.useSSL) {


### PR DESCRIPTION
Updated spelling of `includeSubdomain` to `includeSubDomain`.

This was creating unnecessary error messages on launch as `hsts` had deprecated the old spelling.

![image](https://user-images.githubusercontent.com/7415984/58767333-f3465f80-8589-11e9-91dd-06b5480b50a6.png)
