### PR TITLE
Respect DNT header

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -226,7 +226,8 @@ function showPublishNote (req, res, next) {
         robots: meta.robots || false, // default allow robots
         GA: meta.GA,
         disqus: meta.disqus,
-        cspNonce: res.locals.nonce
+        cspNonce: res.locals.nonce,
+        dnt: req.headers.dnt
       }
       return renderPublish(data, res)
     }).catch(function (err) {
@@ -608,7 +609,8 @@ function showPublishSlide (req, res, next) {
         robots: meta.robots || false, // default allow robots
         GA: meta.GA,
         disqus: meta.disqus,
-        cspNonce: res.locals.nonce
+        cspNonce: res.locals.nonce,
+        dnt: req.headers.dnt
       }
       return renderPublishSlide(data, res)
     }).catch(function (err) {

--- a/public/views/pretty.ejs
+++ b/public/views/pretty.ejs
@@ -63,7 +63,7 @@
         </div>
     </div>
     <div id="ui-toc-affix" class="ui-affix-toc ui-toc-dropdown unselectable hidden-print" data-spy="affix" style="display:none;"></div>
-    <% if(typeof disqus !== 'undefined' && disqus) { %>
+    <% if(typeof disqus !== 'undefined' && disqus && !dnt) { %>
     <div class="container-fluid" style="max-width: 758px; margin-bottom: 40px;">
         <%- include shared/disqus %>
     </div>

--- a/public/views/shared/ga.ejs
+++ b/public/views/shared/ga.ejs
@@ -1,4 +1,4 @@
-<% if(typeof GA !== 'undefined' && GA) { %>
+<% if(typeof GA !== 'undefined' && GA && !dnt) { %>
 <script nonce="<%= cspNonce %>">
 (function (i, s, o, g, r, a, m) {
     i['GoogleAnalyticsObject'] = r;

--- a/public/views/slide.ejs
+++ b/public/views/slide.ejs
@@ -78,7 +78,7 @@
                         <% } %>
                     </small>
                 </div>
-                <% if(typeof disqus !== 'undefined' && disqus) { %>
+                <% if(typeof disqus !== 'undefined' && disqus && !dnt) { %>
                 <div class="slides-disqus">
                     <%- include shared/disqus %>
                 </div>


### PR DESCRIPTION
Do Not Track (DNT) is an old web standard in order to notify pages that
the user doesn't want to be tracked. Even while a lot of pages either
ignore this header or even worse, use it for tracking purposes, the
orignal intention of this header is good and should be adopted.

This patch implements a respect of the DNT header by no longer including
the optional Google Analytics and disqus integrations when sending a DNT
header. This should reduce outside resource usage and help to stay more
private.

This should later-on extended towards other document content (i.e.
iframe based content).

The reason to not change the CDN handling is that CDNs will be
deprecated with next release and removed in long term.