### PR TITLE
Add docker image from LinuxServer.io as an install option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ You can run CodiMD in a number of ways, and we created setup instructions for
 all of these:
 
 * [Docker](docs/setup/docker.md)
+* [Docker (LinuxServer.io)](docs/setup/docker-linuxserver.md)
 * [Kubernetes](docs/setup/kubernetes.md)
 * [Cloudron](docs/setup/cloudron.md)
 * [Heroku](docs/setup/heroku.md)
-* [manual setup](docs/setup/manual-setup.md)
+* [Manual setup](docs/setup/manual-setup.md)
 
 If you do not wish to run your own setup, you can find a commercial offering at
 https://hackmd.io. This is not the same codebase as this one, but it is a very

--- a/docs/setup/docker-linuxserver.md
+++ b/docs/setup/docker-linuxserver.md
@@ -1,0 +1,14 @@
+LinuxServer.io CodiMD Image
+===
+[![](https://img.shields.io/discord/354974912613449730.svg?logo=discord&label=LSIO%20Discord&style=flat-square)](https://discord.gg/YWrKVTn)[![](https://images.microbadger.com/badges/version/linuxserver/codimd.svg)](https://microbadger.com/images/linuxserver/codimd "Get your own version badge on microbadger.com")[![](https://images.microbadger.com/badges/image/linuxserver/codimd.svg)](https://microbadger.com/images/linuxserver/codimd "Get your own version badge on microbadger.com")![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/codimd.svg)![Docker Stars](https://img.shields.io/docker/stars/linuxserver/codimd.svg)[![Build Status](https://ci.linuxserver.io/buildStatus/icon?job=Docker-Pipeline-Builders/docker-codimd/master)](https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-codimd/job/master/)[![](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/codimd/latest/badge.svg)](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/codimd/latest/index.html)
+
+[LinuxServer.io](https://linuxserver.io) have created an Ubuntu based multiarch container for x86-64, arm64 and armhf which supports PDF export from all architectures using PhatomJS. 
+
+It supports all the environmental variables detailed [here](https://github.com/codimd/server/blob/master/docs/configuration-env-vars.md) to modify it according to your needs.
+
+It gets rebuilt on new releases from CodiMD and also weekly if necessary to update any other package changes in the underlying container, making it easy to keep your CodiMD instance up to date.
+
+It also details how to easily [utilise Docker networking to reverse proxy](https://github.com/linuxserver/docker-codimd/#application-setup) CodiMD using their [LetsEncrypt docker image](https://github.com/linuxserver/docker-letsencrypt)
+
+[Github Repository](https://github.com/linuxserver/docker-codimd/)
+[Docker Hub Image](https://hub.docker.com/r/linuxserver/codimd)

--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -1,4 +1,4 @@
-CodiMD by docker container
+CodiMD Docker Image
 ===
 
 [![Try in PWD](https://cdn.rawgit.com/play-with-docker/stacks/cff22438/assets/images/button.png)](http://play-with-docker.com?stack=https://github.com/codimd/container/raw/master/docker-compose.yml&stack_name=codimd)


### PR DESCRIPTION
As requested by @SISheogorath [here](https://github.com/linuxserver/docker-codimd/issues/4#issue-454332233) and further to discussion about previous PR [here.](https://github.com/codimd/server/pull/110#issuecomment-501214087)

Signed-off-by: chbmb <chbmb@linuxserver.io>