### PR TITLE
Fix some minor quirks in the LinuxServer.io docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ You can run CodiMD in a number of ways, and we created setup instructions for
 all of these:
 
 * [Docker](docs/setup/docker.md)
-* [Docker (LinuxServer.io)](docs/setup/docker-linuxserver.md)
 * [Kubernetes](docs/setup/kubernetes.md)
 * [Cloudron](docs/setup/cloudron.md)
+* [LinuxServer.io (multi-arch docker)](docs/setup/docker-linuxserver.md)
 * [Heroku](docs/setup/heroku.md)
 * [Manual setup](docs/setup/manual-setup.md)
 

--- a/docs/setup/docker-linuxserver.md
+++ b/docs/setup/docker-linuxserver.md
@@ -1,14 +1,14 @@
 LinuxServer.io CodiMD Image
 ===
-[![](https://img.shields.io/discord/354974912613449730.svg?logo=discord&label=LSIO%20Discord&style=flat-square)](https://discord.gg/YWrKVTn)[![](https://images.microbadger.com/badges/version/linuxserver/codimd.svg)](https://microbadger.com/images/linuxserver/codimd "Get your own version badge on microbadger.com")[![](https://images.microbadger.com/badges/image/linuxserver/codimd.svg)](https://microbadger.com/images/linuxserver/codimd "Get your own version badge on microbadger.com")![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/codimd.svg)![Docker Stars](https://img.shields.io/docker/stars/linuxserver/codimd.svg)[![Build Status](https://ci.linuxserver.io/buildStatus/icon?job=Docker-Pipeline-Builders/docker-codimd/master)](https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-codimd/job/master/)[![](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/codimd/latest/badge.svg)](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/codimd/latest/index.html)
+[![LinuxServer.io Discord](https://img.shields.io/discord/354974912613449730.svg?logo=discord&label=LSIO%20Discord&style=flat-square)](https://discord.gg/YWrKVTn)[![container version badge](https://images.microbadger.com/badges/version/linuxserver/codimd.svg)](https://microbadger.com/images/linuxserver/codimd "Get your own version badge on microbadger.com")[![container image size badge](https://images.microbadger.com/badges/image/linuxserver/codimd.svg)](https://microbadger.com/images/linuxserver/codimd "Get your own version badge on microbadger.com")![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/codimd.svg)![Docker Stars](https://img.shields.io/docker/stars/linuxserver/codimd.svg)[![Build Status](https://ci.linuxserver.io/buildStatus/icon?job=Docker-Pipeline-Builders/docker-codimd/master)](https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-codimd/job/master/)[![LinuxServer.io CI summary](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/codimd/latest/badge.svg)](https://lsio-ci.ams3.digitaloceanspaces.com/linuxserver/codimd/latest/index.html)
 
-[LinuxServer.io](https://linuxserver.io) have created an Ubuntu based multiarch container for x86-64, arm64 and armhf which supports PDF export from all architectures using PhatomJS. 
+[LinuxServer.io](https://linuxserver.io) have created an Ubuntu-based multi-arch container image for x86-64, arm64 and armhf which supports PDF export from all architectures using PhatomJS.
 
-It supports all the environmental variables detailed [here](https://github.com/codimd/server/blob/master/docs/configuration-env-vars.md) to modify it according to your needs.
+It supports all the environmental variables detailed in the [environment configuration documentation](../configuration-env-vars.md) to modify it according to your needs.
 
 It gets rebuilt on new releases from CodiMD and also weekly if necessary to update any other package changes in the underlying container, making it easy to keep your CodiMD instance up to date.
 
-It also details how to easily [utilise Docker networking to reverse proxy](https://github.com/linuxserver/docker-codimd/#application-setup) CodiMD using their [LetsEncrypt docker image](https://github.com/linuxserver/docker-letsencrypt)
+It also details how to easily [utilize Docker networking to reverse proxy](https://github.com/linuxserver/docker-codimd/#application-setup) CodiMD using their [LetsEncrypt docker image](https://github.com/linuxserver/docker-letsencrypt)
 
-[Github Repository](https://github.com/linuxserver/docker-codimd/)
-[Docker Hub Image](https://hub.docker.com/r/linuxserver/codimd)
+In order to contribute check the LinuxServer.io [GitHub repository](https://github.com/linuxserver/docker-codimd/) for CodiMD.
+And to find all tags and versions of the image, check the [Docker Hub repository](https://hub.docker.com/r/linuxserver/codimd).


### PR DESCRIPTION
The current documents might end up confusing people and are not
completely accessible. This minor fixes should clear up the situation
and add alt texts to all badges, explain the links at the end of the
docs, and list LinuxServer.io in the supported provider section of the
README.

Some reasoning on the change in the listing:
Since we maintain an own container image which is for sure kept updated
on release, this is our first listing, as well as general solutions that
are build on that image, like the K8s integration.

The next listings are integrated provides which allow self-hosting, like
Cloudron and I also consider LinuxServer.io as this kind of providers.
Which try to enable people to run CodiMD on their own hardware or rented
servers in a very easy way, but by using their own images.

As third category I would look at hosted offers, like Heroku, which are
not completely SaaS but far enough away from the self-hostability that
I consider them as an own category. PaaS-based solutions are not as
FOSS-style as we want our setups to be, but of course still supported.

Finally the manual setup. We keep it down here, because we support it,
but don't recommend it in general. It's hard to upgrade and can cause
problems when dependencies are not correctly updated or people don't run
the db migrations.

/cc @CHBMB 