### PR TITLE
Add SVG image detection based on file extension

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,6 +21,8 @@ exports.getImageMimeType = function getImageMimeType (imagePath) {
       return 'image/png'
     case 'tiff':
       return 'image/tiff'
+    case 'svg':
+      return 'image/svg+xml'
     default:
       return undefined
   }


### PR DESCRIPTION
Add simple SVG image detecetion base on the file extension .svg.

This fixes the SVG being delivered as binary/octet-stream and makes it possible to embedd the SVG.