### PR TITLE
DB URL: Secret File Support

### DIFF
--- a/lib/config/dockerSecret.js
+++ b/lib/config/dockerSecret.js
@@ -13,6 +13,7 @@ function getSecret (secret) {
 
 if (fs.existsSync(basePath)) {
   module.exports = {
+    dbURL: getSecret('dbURL'),
     sessionsecret: getSecret('sessionsecret'),
     sslkeypath: getSecret('sslkeypath'),
     sslcertpath: getSecret('sslcertpath'),


### PR DESCRIPTION
Adds a possibility to read the db URL from a file, that could e.g. be provided by a [Docker secret].(https://docs.docker.com/engine/swarm/secrets/).
See https://github.com/codimd/container/pull/36 too.