### PR TITLE
Update badge icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ which lets you use CodiMD from the comfort of your command line.
 
 Licensed under AGPLv3. For our list of contributors, see [AUTHORS](AUTHORS).
 
-[matrix.org-image]: https://img.shields.io/badge/Matrix.org-%23CodiMD@matrix.org-green.svg
+[matrix.org-image]: https://img.shields.io/matrix/codimd:matrix.org?logo=matrix&server_fqdn=matrix.org
 [matrix.org-url]: https://riot.im/app/#/room/#codimd:matrix.org
 [travis-image]: https://travis-ci.org/codimd/server.svg?branch=master
 [travis-url]: https://travis-ci.org/codimd/server
@@ -101,4 +101,4 @@ Licensed under AGPLv3. For our list of contributors, see [AUTHORS](AUTHORS).
 [codimd-community]: https://community.codimd.org
 [codimd-community-calls]: https://community.codimd.org/t/codimd-community-call/19
 [social-mastodon]: https://social.codimd.org/mastodon
-[social-mastodon-image]: https://img.shields.io/badge/social-mastodon-3c99dc.svg
+[social-mastodon-image]: https://img.shields.io/mastodon/follow/18547?domain=https%3A%2F%2Fsocial.snopyta.org&style=social


### PR DESCRIPTION
I just noticed that shields.io provides some nice new badges including
one explicitly for Matrix and one for Mastodon. Since those are really
our platforms, let's get them into our README. Just a cosmetic change.