### PR TITLE
Config: Return String Instead Of Buffer For Docker Secrets

### DIFF
--- a/lib/config/dockerSecret.js
+++ b/lib/config/dockerSecret.js
@@ -7,7 +7,7 @@ const basePath = path.resolve('/var/run/secrets/')
 
 function getSecret (secret) {
   const filePath = path.join(basePath, secret)
-  if (fs.existsSync(filePath)) return fs.readFileSync(filePath).toString('utf8')
+  if (fs.existsSync(filePath)) return fs.readFileSync(filePath, 'utf-8')
   return undefined
 }
 

--- a/lib/config/dockerSecret.js
+++ b/lib/config/dockerSecret.js
@@ -7,7 +7,7 @@ const basePath = path.resolve('/var/run/secrets/')
 
 function getSecret (secret) {
   const filePath = path.join(basePath, secret)
-  if (fs.existsSync(filePath)) return fs.readFileSync(filePath)
+  if (fs.existsSync(filePath)) return fs.readFileSync(filePath).toString('utf8')
   return undefined
 }
 


### PR DESCRIPTION
Prevents "TypeError: Cannot freeze array buffer views with elements".