### PR TITLE
Added endpoint for note-creation with given alias

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -41,12 +41,12 @@ var response = {
   errorServiceUnavailable: function (res) {
     res.status(503).send("I'm busy right now, try again later.")
   },
-  newNote: newNote,
   showNote: showNote,
   showPublishNote: showPublishNote,
   showPublishSlide: showPublishSlide,
   showIndex: showIndex,
   noteActions: noteActions,
+  postNote: postNote,
   publishNoteActions: publishNoteActions,
   publishSlideActions: publishSlideActions,
   githubActions: githubActions,
@@ -107,8 +107,7 @@ function responseCodiMD (res, note) {
   })
 }
 
-function newNote (req, res, next) {
-  var owner = null
+function postNote (req, res, next) {
   var body = ''
   if (req.body && req.body.length > config.documentMaxLength) {
     return response.errorTooLong(res)
@@ -116,14 +115,25 @@ function newNote (req, res, next) {
     body = req.body
   }
   body = body.replace(/[\r]/g, '')
+  return newNote(req, res, body)
+}
+
+function newNote (req, res, body) {
+  var owner = null
+  var noteId = req.params.noteId ? req.params.noteId : null
   if (req.isAuthenticated()) {
     owner = req.user.id
   } else if (!config.allowAnonymous) {
     return response.errorForbidden(res)
   }
+  if (config.allowFreeURL && noteId && !config.forbiddenNoteIDs.includes(noteId)) {
+    req.alias = noteId
+  } else if (noteId) {
+    return req.method === 'POST' ? response.errorForbidden(res) : response.errorNotFound(res)
+  }
   models.Note.create({
     ownerId: owner,
-    alias: req.alias ? req.alias : (config.allowFreeURL ? (req.params.alias ? req.params.alias : null) : null),
+    alias: req.alias ? req.alias : null,
     content: body
   }).then(function (note) {
     return res.redirect(config.serverURL + '/' + (note.alias ? note.alias : models.Note.encodeNoteId(note.id)))
@@ -144,7 +154,6 @@ function checkViewPermission (req, note) {
 }
 
 function findNote (req, res, callback, include) {
-  var noteId = req.params.noteId
   var id = req.params.noteId || req.params.shortid
   models.Note.parseNoteId(id, function (err, _id) {
     if (err) {
@@ -158,12 +167,7 @@ function findNote (req, res, callback, include) {
       include: include || null
     }).then(function (note) {
       if (!note) {
-        if (config.allowFreeURL && noteId && !config.forbiddenNoteIDs.includes(noteId)) {
-          req.alias = noteId
-          return newNote(req, res)
-        } else {
-          return response.errorNotFound(res)
-        }
+        return newNote(req, res, null)
       }
       if (!checkViewPermission(req, note)) {
         return response.errorForbidden(res)

--- a/lib/response.js
+++ b/lib/response.js
@@ -123,10 +123,10 @@ function newNote (req, res, next) {
   }
   models.Note.create({
     ownerId: owner,
-    alias: req.alias ? req.alias : null,
+    alias: req.alias ? req.alias : (config.allowFreeURL ? (req.params.alias ? req.params.alias : null) : null),
     content: body
   }).then(function (note) {
-    return res.redirect(config.serverURL + '/' + models.Note.encodeNoteId(note.id))
+    return res.redirect(config.serverURL + '/' + (note.alias ? note.alias : models.Note.encodeNoteId(note.id)))
   }).catch(function (err) {
     logger.error(err)
     return response.errorInternalError(res)

--- a/lib/web/noteRouter.js
+++ b/lib/web/noteRouter.js
@@ -9,11 +9,11 @@ const { markdownParser } = require('./utils')
 const noteRouter = module.exports = Router()
 
 // get new note
-noteRouter.get('/new', response.newNote)
+noteRouter.get('/new', response.postNote)
 // post new note with content
-noteRouter.post('/new', markdownParser, response.newNote)
+noteRouter.post('/new', markdownParser, response.postNote)
 // post new note with content and alias
-noteRouter.post('/new/:alias', markdownParser, response.newNote)
+noteRouter.post('/new/:noteId', markdownParser, response.postNote)
 // get publish note
 noteRouter.get('/s/:shortid', response.showPublishNote)
 // publish note actions

--- a/lib/web/noteRouter.js
+++ b/lib/web/noteRouter.js
@@ -12,6 +12,8 @@ const noteRouter = module.exports = Router()
 noteRouter.get('/new', response.newNote)
 // post new note with content
 noteRouter.post('/new', markdownParser, response.newNote)
+// post new note with content and alias
+noteRouter.post('/new/:alias', markdownParser, response.newNote)
 // get publish note
 noteRouter.get('/s/:shortid', response.showPublishNote)
 // publish note actions


### PR DESCRIPTION
Added a new endpoint `/new/:noteId` that allows creation of a note by HTTP-POST with the specified alias as noteId.