### PR TITLE
Fixed #179 (redirect loop with a trailing slash)

### DIFF
--- a/app.js
+++ b/app.js
@@ -126,9 +126,9 @@ app.use(i18n.init)
 
 // routes without sessions
 // static files
-app.use('/', express.static(path.join(__dirname, '/public'), { maxAge: config.staticCacheTime, index: false }))
-app.use('/docs', express.static(path.resolve(__dirname, config.docsPath), { maxAge: config.staticCacheTime }))
-app.use('/uploads', express.static(path.resolve(__dirname, config.uploadsPath), { maxAge: config.staticCacheTime }))
+app.use('/', express.static(path.join(__dirname, '/public'), { maxAge: config.staticCacheTime, index: false, redirect: false }))
+app.use('/docs', express.static(path.resolve(__dirname, config.docsPath), { maxAge: config.staticCacheTime, redirect: false }))
+app.use('/uploads', express.static(path.resolve(__dirname, config.uploadsPath), { maxAge: config.staticCacheTime, redirect: false }))
 app.use('/default.md', express.static(path.resolve(__dirname, config.defaultNotePath), { maxAge: config.staticCacheTime }))
 
 // session

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -32,7 +32,7 @@ module.exports = {
   allowAnonymous: true,
   allowAnonymousEdits: false,
   allowFreeURL: false,
-  forbiddenNoteIDs: ['robots.txt', 'favicon.ico', 'api'],
+  forbiddenNoteIDs: ['robots.txt', 'favicon.ico', 'api', 'build', 'css', 'docs', 'fonts', 'js', 'uploads', 'vendor', 'views'],
   defaultPermission: 'editable',
   dbURL: '',
   db: {},


### PR DESCRIPTION
Requests for `/build`, `/uploads` and so on will not result in a redirection loop anymore but respond with an HTTP 404.

Maybe we should add specific routes for these directories that return an HTTP 403?