### PR TITLE
Add customizable opengraph metadata for notes (see #40)

### DIFF
--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -409,8 +409,17 @@ module.exports = function (sequelize, DataTypes) {
       if (meta.GA && (typeof meta.GA === 'string' || typeof meta.GA === 'number')) { _meta.GA = meta.GA }
       if (meta.disqus && (typeof meta.disqus === 'string' || typeof meta.disqus === 'number')) { _meta.disqus = meta.disqus }
       if (meta.slideOptions && (typeof meta.slideOptions === 'object')) { _meta.slideOptions = meta.slideOptions }
+      if (meta.opengraph && (typeof meta.opengraph === 'object')) { _meta.opengraph = meta.opengraph }
     }
     return _meta
+  }
+  Note.parseOpengraph = function (meta, title) {
+    var _ogdata = {}
+    if (meta.opengraph) { _ogdata = meta.opengraph }
+    if (!(_ogdata.title && (typeof _ogdata.title === 'string' || typeof _ogdata.title === 'number'))) { _ogdata.title = title }
+    if (!(_ogdata.description && (typeof _ogdata.description === 'string' || typeof _ogdata.description === 'number'))) { _ogdata.description = meta.description || '' }
+    if (!(_ogdata.type && (typeof _ogdata.type === 'string'))) { _ogdata.type = 'website' }
+    return _ogdata
   }
   Note.updateAuthorshipByOperation = function (operation, userId, authorships) {
     var index = 0

--- a/lib/response.js
+++ b/lib/response.js
@@ -98,12 +98,14 @@ function responseCodiMD (res, note) {
   var meta = models.Note.parseMeta(extracted.meta)
   var title = models.Note.decodeTitle(note.title)
   title = models.Note.generateWebTitle(meta.title || title)
+  var opengraph = models.Note.parseOpengraph(meta, title)
   res.set({
     'Cache-Control': 'private', // only cache by client
     'X-Robots-Tag': 'noindex, nofollow' // prevent crawling
   })
   res.render('codimd.ejs', {
-    title: title
+    title: title,
+    opengraph: opengraph
   })
 }
 
@@ -217,6 +219,7 @@ function showPublishNote (req, res, next) {
       var updatetime = note.lastchangeAt
       var title = models.Note.decodeTitle(note.title)
       title = models.Note.generateWebTitle(meta.title || title)
+      var ogdata = models.Note.parseOpengraph(meta, title)
       var data = {
         title: title,
         description: meta.description || (markdown ? models.Note.generateDescription(markdown) : null),
@@ -232,7 +235,8 @@ function showPublishNote (req, res, next) {
         GA: meta.GA,
         disqus: meta.disqus,
         cspNonce: res.locals.nonce,
-        dnt: req.headers.dnt
+        dnt: req.headers.dnt,
+        opengraph: ogdata
       }
       return renderPublish(data, res)
     }).catch(function (err) {

--- a/public/docs/yaml-metadata.md
+++ b/public/docs/yaml-metadata.md
@@ -159,3 +159,20 @@ slideOptions:
   transition: fade
   theme: white
 ```
+
+opengraph
+---
+This option allows you to override the default generated opengraph metadata.  
+See the [OpenGraph protocol documentation](https://ogp.me) for more information.
+
+**Notice: always use two spaces as indention in YAML metadata!**
+
+> default: not set (uses auto-generated metadata) 
+
+**Example**
+```yml
+opengraph:
+  title: Special title for OpenGraph protocol
+  image: https://dummyimage.com/600x600/000/fff
+  image:type: image/png
+```

--- a/public/views/codimd/head.ejs
+++ b/public/views/codimd/head.ejs
@@ -4,6 +4,10 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black">
 <meta name="mobile-web-app-capable" content="yes">
+<% for (var og in opengraph) { %>
+<% if (opengraph.hasOwnProperty(og) && opengraph[og].trim() !== '') { %>
+<meta property="og:<%= og %>" content="<%= opengraph[og] %>">
+<% }} %>
 <title><%= title %></title>
 <link rel="icon" type="image/png" href="<%- serverURL %>/favicon.png">
 <link rel="apple-touch-icon" href="<%- serverURL %>/apple-touch-icon.png">

--- a/public/views/codimd/head.ejs
+++ b/public/views/codimd/head.ejs
@@ -6,8 +6,12 @@
 <meta name="mobile-web-app-capable" content="yes">
 <% for (var og in opengraph) { %>
 <% if (opengraph.hasOwnProperty(og) && opengraph[og].trim() !== '') { %>
-<meta property="og:<%= og %>" content="<%= opengraph[og] %>">
-<% }} %>
+<meta property="og:<%- og %>" content="<%- opengraph[og] %>">
+<% }} if (!opengraph.hasOwnProperty('image')) { %>
+<meta property="og:image" content="<%- serverURL %>/codimd-icon-1024.png">
+<meta property="og:image:alt" content="CodiMD logo">
+<meta property="og:image:type" content="image/png">
+<% } %>
 <title><%= title %></title>
 <link rel="icon" type="image/png" href="<%- serverURL %>/favicon.png">
 <link rel="apple-touch-icon" href="<%- serverURL %>/apple-touch-icon.png">

--- a/public/views/index/head.ejs
+++ b/public/views/index/head.ejs
@@ -9,12 +9,10 @@
 <meta property="og:title" content="CodiMD - <%= __('Collaborative markdown notes') %>">
 <meta property="og:description" content="<%= __('Best way to write and share your knowledge in markdown.') %>">
 <meta property="og:type" content="website">
-<% if (serverURL !== "") { %>
 <meta property="og:url" content="<%- serverURL %>">
-<meta property="og:image" content="<%- serverURL %>/favicon.png">
+<meta property="og:image" content="<%- serverURL %>/codimd-icon-1024.png">
 <meta property="og:image:alt" content="CodiMD logo">
 <meta property="og:image:type" content="image/png">
-<% } %>
 <title>CodiMD - <%= __('Collaborative markdown notes') %></title>
 <link rel="icon" type="image/png" href="<%- serverURL %>/favicon.png">
 <link rel="apple-touch-icon" href="<%- serverURL %>/apple-touch-icon.png">

--- a/public/views/index/head.ejs
+++ b/public/views/index/head.ejs
@@ -6,6 +6,15 @@
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="description" content="<%= __('Best way to write and share your knowledge in markdown.') %>">
 <meta name="keywords" content="Collaborative, Markdown, Notes">
+<meta property="og:title" content="CodiMD - <%= __('Collaborative markdown notes') %>">
+<meta property="og:description" content="<%= __('Best way to write and share your knowledge in markdown.') %>">
+<meta property="og:type" content="website">
+<% if (serverURL !== "") { %>
+<meta property="og:url" content="<%- serverURL %>">
+<meta property="og:image" content="<%- serverURL %>/favicon.png">
+<meta property="og:image:alt" content="CodiMD logo">
+<meta property="og:image:type" content="image/png">
+<% } %>
 <title>CodiMD - <%= __('Collaborative markdown notes') %></title>
 <link rel="icon" type="image/png" href="<%- serverURL %>/favicon.png">
 <link rel="apple-touch-icon" href="<%- serverURL %>/apple-touch-icon.png">

--- a/public/views/pretty.ejs
+++ b/public/views/pretty.ejs
@@ -17,7 +17,11 @@
     <% for (var og in opengraph) { %>
     <% if (opengraph.hasOwnProperty(og) && opengraph[og].trim() !== '') { %>
     <meta property="og:<%= og %>" content="<%= opengraph[og] %>">
-    <% }} %>
+    <% }} if (!opengraph.hasOwnProperty('image')) { %>
+    <meta property="og:image" content="<%- serverURL %>/codimd-icon-1024.png">
+    <meta property="og:image:alt" content="CodiMD logo">
+    <meta property="og:image:type" content="image/png">
+    <% } %>
     <title><%= title %></title>
     <link rel="icon" type="image/png" href="<%- serverURL %>/favicon.png">
     <link rel="apple-touch-icon" href="<%- serverURL %>/apple-touch-icon.png">

--- a/public/views/pretty.ejs
+++ b/public/views/pretty.ejs
@@ -14,6 +14,10 @@
     <% if(typeof description !== 'undefined' && description) { %>
     <meta name="description" content="<%= description %>">
     <% } %>
+    <% for (var og in opengraph) { %>
+    <% if (opengraph.hasOwnProperty(og) && opengraph[og].trim() !== '') { %>
+    <meta property="og:<%= og %>" content="<%= opengraph[og] %>">
+    <% }} %>
     <title><%= title %></title>
     <link rel="icon" type="image/png" href="<%- serverURL %>/favicon.png">
     <link rel="apple-touch-icon" href="<%- serverURL %>/apple-touch-icon.png">


### PR DESCRIPTION
Adds fixed opengraph metadata to the CodiMD index page and modifiable opengraph metadata to the notes. By default, the title and description of the note will be used, but with the YAML frontmatter this can be overridden.
See feature request #40 