### PR TITLE
Fix broken error template due to missing opengraph

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -58,7 +58,8 @@ function responseError (res, code, detail, msg) {
     title: code + ' ' + detail + ' ' + msg,
     code: code,
     detail: detail,
-    msg: msg
+    msg: msg,
+    opengraph: []
   })
 }
 


### PR DESCRIPTION
This regression bug was caused by the error page using the `codimd/head`
template. This resulted in error messages like this:

```
ReferenceError: /codimd/public/views/error.ejs:5
    3|
    4| <head>
 >> 5|     <%- include codimd/head %>
    6|     <link rel="stylesheet" href="<%- serverURL %>/css/center.css">
    7| </head>
    8|
/codimd/public/views/codimd/head.ejs:7
    5| <meta name="apple-mobile-web-app-status-bar-style" content="black">
    6| <meta name="mobile-web-app-capable" content="yes">
 >> 7| <% for (var og in opengraph) { %>
    8| <% if (opengraph.hasOwnProperty(og) && opengraph[og].trim() !== '') { %>
    9| <meta property="og:<%- og %>" content="<%- opengraph[og] %>">
    10| <% }} if (!opengraph.hasOwnProperty('image')) { %>
opengraph is not defined
    at eval (eval at compile (/codimd/node_modules/ejs/lib/ejs.js:618:12), <anonymous>:18:23)
    at eval (eval at compile (/codimd/node_modules/ejs/lib/ejs.js:618:12), <anonymous>:99:10)
    at returnedFn (/codimd/node_modules/ejs/lib/ejs.js:653:17)
    at tryHandleCache (/codimd/node_modules/ejs/lib/ejs.js:251:36)
    at View.exports.renderFile [as engine] (/codimd/node_modules/ejs/lib/ejs.js:482:10)
    at View.render (/codimd/node_modules/express/lib/view.js:135:8)
    at tryRender (/codimd/node_modules/express/lib/application.js:640:10)
    at Function.render (/codimd/node_modules/express/lib/application.js:592:3)
    at ServerResponse.render (/codimd/node_modules/express/lib/response.js:1012:7)
    at responseError (/codimd/lib/response.js:57:20)
    at Object.errorNotFound (/codimd/lib/response.js:30:5)
    at newNote (/codimd/lib/response.js:134:76)
    at /codimd/lib/response.js:172:16
    at tryCatcher (/codimd/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/codimd/node_modules/bluebird/js/release/promise.js:517:31)
    at Promise._settlePromise (/codimd/node_modules/bluebird/js/release/promise.js:574:18)
    at Promise._settlePromise0 (/codimd/node_modules/bluebird/js/release/promise.js:619:10)
    at Promise._settlePromises (/codimd/node_modules/bluebird/js/release/promise.js:699:18)
    at _drainQueueStep (/codimd/node_modules/bluebird/js/release/async.js:138:12)
    at _drainQueue (/codimd/node_modules/bluebird/js/release/async.js:131:9)
    at Async._drainQueues (/codimd/node_modules/bluebird/js/release/async.js:147:5)
    at Immediate.Async.drainQueues (/codimd/node_modules/bluebird/js/release/async.js:17:14)

```

The fix for that is rather trivial. We simply provide an empty array of
metadata when generating the error template.