### PR TITLE
Allow to generate lower case header references through the config

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -123,6 +123,7 @@
         {
           "connectionString": "change this",
           "container": "change this"
-        }
+        },
+        "linkifyHeaderStyle": "gfm"
     }
 }

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -157,5 +157,6 @@ module.exports = {
   allowEmailRegister: true,
   allowGravatar: true,
   allowPDFExport: true,
-  openID: false
+  openID: false,
+  linkifyHeaderStyle: 'keep-case'
 }

--- a/lib/web/statusRouter.js
+++ b/lib/web/statusRouter.js
@@ -96,7 +96,8 @@ statusRouter.get('/config', function (req, res) {
     debug: config.debug,
     version: config.fullversion,
     DROPBOX_APP_KEY: config.dropbox.appKey,
-    allowedUploadMimeTypes: config.allowedUploadMimeTypes
+    allowedUploadMimeTypes: config.allowedUploadMimeTypes,
+    linkifyHeaderStyle: config.linkifyHeaderStyle
   }
   res.set({
     'Cache-Control': 'private', // only cache by client

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -164,11 +164,11 @@ export function renderTags (view) {
 }
 
 function slugifyWithUTF8 (text) {
-  // remove html tags and trim spaces
+  // remove HTML tags and trim spaces
   let newText = S(text).trim().stripTags().s
-  // replace all spaces in between to dashes
+  // replace space between words with dashes
   newText = newText.replace(/\s+/g, '-')
-  // slugify string to make it valid for attribute
+  // slugify string to make it valid as an attribute
   newText = newText.replace(/([!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, '')
   return newText
 }

--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -833,7 +833,11 @@ const linkifyAnchors = (level, containingElement) => {
     if (header.getElementsByClassName('anchor').length === 0) {
       if (typeof header.id === 'undefined' || header.id === '') {
         // to escape characters not allow in css and humanize
-        const id = slugifyWithUTF8(getHeaderContent(header))
+        let id = slugifyWithUTF8(getHeaderContent(header))
+        // to make compatible with GitHub, GitLab, Pandoc and many more
+        if (window.linkifyHeaderStyle !== 'keep-case') {
+          id = id.toLowerCase()
+        }
         header.id = id
       }
       if (!(typeof header.id === 'undefined' || header.id === '')) {

--- a/public/js/lib/common/constant.ejs
+++ b/public/js/lib/common/constant.ejs
@@ -5,4 +5,6 @@ window.version = '<%- version %>'
 
 window.allowedUploadMimeTypes = <%- JSON.stringify(allowedUploadMimeTypes) %>
 
+window.linkifyHeaderStyle = <%- JSON.stringify(linkifyHeaderStyle) %>
+
 window.DROPBOX_APP_KEY = '<%- DROPBOX_APP_KEY %>'


### PR DESCRIPTION
Allow to generate lower case header references through the config

This makes the references consistent/compatible with GitHub,
GitLab, Pandoc and many other tools.

This behavior can be enabled in _config.json_ with:

```
"linkifyHeaderStyle": "gfm"
```

See [the related issue on HackMd](https://github.com/hackmdio/codimd/issues/1305).