### PR TITLE
Don't accept sandbox attribute

### DIFF
--- a/public/js/render.js
+++ b/public/js/render.js
@@ -20,7 +20,7 @@ whiteList['style'] = []
 // allow kbd tag
 whiteList['kbd'] = []
 // allow ifram tag with some safe attributes
-whiteList['iframe'] = ['allowfullscreen', 'name', 'referrerpolicy', 'sandbox', 'src', 'width', 'height']
+whiteList['iframe'] = ['allowfullscreen', 'name', 'referrerpolicy', 'src', 'width', 'height']
 // allow summary tag
 whiteList['summary'] = []
 // allow ruby tag


### PR DESCRIPTION
Because sandbox is whitelist attribute, attacker will be able to create iframe that has more permission than default.

Signed-off-by: RyotaK <49341894+ry0tak@users.noreply.github.com>