### PR TITLE
Fix compatibility with MathJax 2.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",
     "markdown-pdf": "^10.0.0",
-    "mathjax": "~2.7.0",
+    "mathjax": "~2.7.6",
     "mattermost": "^3.4.0",
     "mermaid": "~8.2.3",
     "meta-marked": "git+https://github.com/codimd/meta-marked#semver:^0.4.5",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -131,12 +131,20 @@ module.exports = {
     }),
     new CopyWebpackPlugin([
       {
-        context: path.join(__dirname, 'node_modules/mathjax'),
+        context: path.join(__dirname, 'node_modules/mathjax/unpacked'),
         from: {
           glob: '**/*',
           dot: false
         },
         to: 'MathJax/'
+      },
+      {
+        context: path.join(__dirname, 'node_modules/mathjax/fonts'),
+        from: {
+          glob: '**/*',
+          dot: false
+        },
+        to: 'fonts/'
       },
       {
         context: path.join(__dirname, 'node_modules/emojify.js'),


### PR DESCRIPTION
MathJax 2.7.6 changed their packaging structure and stopped to include `MathJax.js` in the package root. This PR copies the MathJax JS from the `unpacked` folder and the required fonts seperately.

Signed-off-by: David Mehren <dmehren1@gmail.com>