### PR TITLE
Remove unused webpack plugins from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,14 +175,12 @@
     "babel-runtime": "^6.26.0",
     "copy-webpack-plugin": "^4.5.2",
     "css-loader": "^1.0.0",
-    "ejs-loader": "^0.3.1",
     "eslint": "^5.9.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "exports-loader": "^0.7.0",
     "expose-loader": "^0.7.5",
     "file-loader": "^2.0.0",
     "html-webpack-plugin": "4.0.0-beta.2",
@@ -197,12 +195,10 @@
     "script-loader": "^0.7.2",
     "string-loader": "^0.0.1",
     "style-loader": "^0.21.0",
-    "uglifyjs-webpack-plugin": "^1.2.7",
     "url-loader": "^1.0.1",
     "webpack": "^4.14.0",
     "webpack-cli": "^3.1.0",
-    "webpack-merge": "^4.1.4",
-    "webpack-parallel-uglify-plugin": "^1.1.0"
+    "webpack-merge": "^4.1.4"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.0",


### PR DESCRIPTION
`exports-loader` and `ejs-loader` seem to be not used anywhere, the `uglifyjs` plugins are replaced by the `TerserPlugin` integrated in Webpack 4.

Signed-off-by: David Mehren <dmehren1@gmail.com>