### PR TITLE
Fixing redirection after SAML login

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -7,7 +7,7 @@ module.exports = {
       responseError(res, '403', 'Forbidden', 'oh no.')
     } else {
       if (!req.session) req.session = {}
-      req.session.returnTo = req.originalUrl || config.serverUrl + '/';
+      req.session.returnTo = req.originalUrl || config.serverUrl + '/'
       req.flash('error', 'You are not allowed to access this page. Maybe try logging in?')
       res.redirect(config.serverURL + '/')
     }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -6,6 +6,8 @@ module.exports = {
     if (req.user) {
       responseError(res, '403', 'Forbidden', 'oh no.')
     } else {
+      if (!req.session) req.session = {}
+      req.session.returnTo = req.originalUrl || config.serverUrl + '/';
       req.flash('error', 'You are not allowed to access this page. Maybe try logging in?')
       res.redirect(config.serverURL + '/')
     }

--- a/lib/web/auth/dropbox/index.js
+++ b/lib/web/auth/dropbox/index.js
@@ -4,7 +4,7 @@ const Router = require('express').Router
 const passport = require('passport')
 const DropboxStrategy = require('passport-dropbox-oauth2').Strategy
 const config = require('../../../config')
-const { setReturnToFromReferer, passportGeneralCallback } = require('../utils')
+const { passportGeneralCallback } = require('../utils')
 
 let dropboxAuth = module.exports = Router()
 
@@ -16,7 +16,6 @@ passport.use(new DropboxStrategy({
 }, passportGeneralCallback))
 
 dropboxAuth.get('/auth/dropbox', function (req, res, next) {
-  setReturnToFromReferer(req)
   passport.authenticate('dropbox-oauth2')(req, res, next)
 })
 

--- a/lib/web/auth/email/index.js
+++ b/lib/web/auth/email/index.js
@@ -7,7 +7,6 @@ const LocalStrategy = require('passport-local').Strategy
 const config = require('../../../config')
 const models = require('../../../models')
 const logger = require('../../../logger')
-const { setReturnToFromReferer } = require('../utils')
 const { urlencodedParser } = require('../../utils')
 const errors = require('../../../errors')
 
@@ -71,7 +70,6 @@ if (config.allowEmailRegister) {
 emailAuth.post('/login', urlencodedParser, function (req, res, next) {
   if (!req.body.email || !req.body.password) return errors.errorBadRequest(res)
   if (!validator.isEmail(req.body.email)) return errors.errorBadRequest(res)
-  setReturnToFromReferer(req)
   passport.authenticate('local', {
     successReturnToOrRedirect: config.serverURL + '/',
     failureRedirect: config.serverURL + '/',

--- a/lib/web/auth/facebook/index.js
+++ b/lib/web/auth/facebook/index.js
@@ -5,7 +5,7 @@ const passport = require('passport')
 const FacebookStrategy = require('passport-facebook').Strategy
 
 const config = require('../../../config')
-const { setReturnToFromReferer, passportGeneralCallback } = require('../utils')
+const { passportGeneralCallback } = require('../utils')
 
 let facebookAuth = module.exports = Router()
 
@@ -16,7 +16,6 @@ passport.use(new FacebookStrategy({
 }, passportGeneralCallback))
 
 facebookAuth.get('/auth/facebook', function (req, res, next) {
-  setReturnToFromReferer(req)
   passport.authenticate('facebook')(req, res, next)
 })
 

--- a/lib/web/auth/github/index.js
+++ b/lib/web/auth/github/index.js
@@ -5,7 +5,7 @@ const passport = require('passport')
 const GithubStrategy = require('passport-github').Strategy
 const config = require('../../../config')
 const response = require('../../../response')
-const { setReturnToFromReferer, passportGeneralCallback } = require('../utils')
+const { passportGeneralCallback } = require('../utils')
 
 let githubAuth = module.exports = Router()
 
@@ -16,7 +16,6 @@ passport.use(new GithubStrategy({
 }, passportGeneralCallback))
 
 githubAuth.get('/auth/github', function (req, res, next) {
-  setReturnToFromReferer(req)
   passport.authenticate('github')(req, res, next)
 })
 

--- a/lib/web/auth/gitlab/index.js
+++ b/lib/web/auth/gitlab/index.js
@@ -5,7 +5,7 @@ const passport = require('passport')
 const GitlabStrategy = require('passport-gitlab2').Strategy
 const config = require('../../../config')
 const response = require('../../../response')
-const { setReturnToFromReferer, passportGeneralCallback } = require('../utils')
+const { passportGeneralCallback } = require('../utils')
 
 let gitlabAuth = module.exports = Router()
 
@@ -18,7 +18,6 @@ passport.use(new GitlabStrategy({
 }, passportGeneralCallback))
 
 gitlabAuth.get('/auth/gitlab', function (req, res, next) {
-  setReturnToFromReferer(req)
   passport.authenticate('gitlab')(req, res, next)
 })
 

--- a/lib/web/auth/google/index.js
+++ b/lib/web/auth/google/index.js
@@ -4,7 +4,7 @@ const Router = require('express').Router
 const passport = require('passport')
 var GoogleStrategy = require('passport-google-oauth20').Strategy
 const config = require('../../../config')
-const { setReturnToFromReferer, passportGeneralCallback } = require('../utils')
+const { passportGeneralCallback } = require('../utils')
 
 let googleAuth = module.exports = Router()
 
@@ -16,7 +16,6 @@ passport.use(new GoogleStrategy({
 }, passportGeneralCallback))
 
 googleAuth.get('/auth/google', function (req, res, next) {
-  setReturnToFromReferer(req)
   passport.authenticate('google', { scope: ['profile'] })(req, res, next)
 })
 // google auth callback

--- a/lib/web/auth/ldap/index.js
+++ b/lib/web/auth/ldap/index.js
@@ -6,7 +6,6 @@ const LDAPStrategy = require('passport-ldapauth')
 const config = require('../../../config')
 const models = require('../../../models')
 const logger = require('../../../logger')
-const { setReturnToFromReferer } = require('../utils')
 const { urlencodedParser } = require('../../utils')
 const errors = require('../../../errors')
 
@@ -82,7 +81,6 @@ passport.use(new LDAPStrategy({
 
 ldapAuth.post('/auth/ldap', urlencodedParser, function (req, res, next) {
   if (!req.body.username || !req.body.password) return errors.errorBadRequest(res)
-  setReturnToFromReferer(req)
   passport.authenticate('ldapauth', {
     successReturnToOrRedirect: config.serverURL + '/',
     failureRedirect: config.serverURL + '/',

--- a/lib/web/auth/mattermost/index.js
+++ b/lib/web/auth/mattermost/index.js
@@ -5,7 +5,7 @@ const passport = require('passport')
 const Mattermost = require('mattermost')
 const OAuthStrategy = require('passport-oauth2').Strategy
 const config = require('../../../config')
-const { setReturnToFromReferer, passportGeneralCallback } = require('../utils')
+const { passportGeneralCallback } = require('../utils')
 
 const mattermost = new Mattermost.Client()
 
@@ -36,7 +36,6 @@ mattermostStrategy.userProfile = (accessToken, done) => {
 passport.use(mattermostStrategy)
 
 mattermostAuth.get('/auth/mattermost', function (req, res, next) {
-  setReturnToFromReferer(req)
   passport.authenticate('oauth2')(req, res, next)
 })
 

--- a/lib/web/auth/oauth2/index.js
+++ b/lib/web/auth/oauth2/index.js
@@ -4,7 +4,7 @@ const Router = require('express').Router
 const passport = require('passport')
 const { Strategy, InternalOAuthError } = require('passport-oauth2')
 const config = require('../../../config')
-const { setReturnToFromReferer, passportGeneralCallback } = require('../utils')
+const { passportGeneralCallback } = require('../utils')
 
 let oauth2Auth = module.exports = Router()
 
@@ -93,7 +93,6 @@ passport.use(new OAuth2CustomStrategy({
 }, passportGeneralCallback))
 
 oauth2Auth.get('/auth/oauth2', function (req, res, next) {
-  setReturnToFromReferer(req)
   passport.authenticate('oauth2')(req, res, next)
 })
 

--- a/lib/web/auth/openid/index.js
+++ b/lib/web/auth/openid/index.js
@@ -7,7 +7,6 @@ const config = require('../../../config')
 const models = require('../../../models')
 const logger = require('../../../logger')
 const { urlencodedParser } = require('../../utils')
-const { setReturnToFromReferer } = require('../utils')
 
 let openIDAuth = module.exports = Router()
 
@@ -48,7 +47,6 @@ passport.use(new OpenIDStrategy({
 }))
 
 openIDAuth.post('/auth/openid', urlencodedParser, function (req, res, next) {
-  setReturnToFromReferer(req)
   passport.authenticate('openid')(req, res, next)
 })
 

--- a/lib/web/auth/saml/index.js
+++ b/lib/web/auth/saml/index.js
@@ -7,7 +7,6 @@ const config = require('../../../config')
 const models = require('../../../models')
 const logger = require('../../../logger')
 const { urlencodedParser } = require('../../utils')
-const { setReturnToFromReferer } = require('../utils')
 const fs = require('fs')
 const intersection = function (array1, array2) { return array1.filter((n) => array2.includes(n)) }
 
@@ -77,13 +76,12 @@ passport.use(new SamlStrategy({
   })
 }))
 
-samlAuth.get('/auth/saml', function (req, res, next) {
-  setReturnToFromReferer(req)
+samlAuth.get('/auth/saml',
   passport.authenticate('saml', {
     successReturnToOrRedirect: config.serverURL + '/',
     failureRedirect: config.serverURL + '/'
-  })(req, res, next)
-})
+  })
+)
 
 samlAuth.post('/auth/saml/callback', urlencodedParser,
   passport.authenticate('saml', {

--- a/lib/web/auth/saml/index.js
+++ b/lib/web/auth/saml/index.js
@@ -77,14 +77,13 @@ passport.use(new SamlStrategy({
   })
 }))
 
-samlAuth.get('/auth/saml',function(req,res,next) {
+samlAuth.get('/auth/saml', function (req, res, next) {
   setReturnToFromReferer(req)
   passport.authenticate('saml', {
     successReturnToOrRedirect: config.serverURL + '/',
     failureRedirect: config.serverURL + '/'
-  })(req,res,next)
-  }
-)
+  })(req, res, next)
+})
 
 samlAuth.post('/auth/saml/callback', urlencodedParser,
   passport.authenticate('saml', {

--- a/lib/web/auth/saml/index.js
+++ b/lib/web/auth/saml/index.js
@@ -7,6 +7,7 @@ const config = require('../../../config')
 const models = require('../../../models')
 const logger = require('../../../logger')
 const { urlencodedParser } = require('../../utils')
+const { setReturnToFromReferer } = require('../utils')
 const fs = require('fs')
 const intersection = function (array1, array2) { return array1.filter((n) => array2.includes(n)) }
 
@@ -76,11 +77,13 @@ passport.use(new SamlStrategy({
   })
 }))
 
-samlAuth.get('/auth/saml',
+samlAuth.get('/auth/saml',function(req,res,next) {
+  setReturnToFromReferer(req)
   passport.authenticate('saml', {
     successReturnToOrRedirect: config.serverURL + '/',
     failureRedirect: config.serverURL + '/'
-  })
+  })(req,res,next)
+  }
 )
 
 samlAuth.post('/auth/saml/callback', urlencodedParser,

--- a/lib/web/auth/twitter/index.js
+++ b/lib/web/auth/twitter/index.js
@@ -5,7 +5,7 @@ const passport = require('passport')
 const TwitterStrategy = require('passport-twitter').Strategy
 
 const config = require('../../../config')
-const { setReturnToFromReferer, passportGeneralCallback } = require('../utils')
+const { passportGeneralCallback } = require('../utils')
 
 let twitterAuth = module.exports = Router()
 
@@ -16,7 +16,6 @@ passport.use(new TwitterStrategy({
 }, passportGeneralCallback))
 
 twitterAuth.get('/auth/twitter', function (req, res, next) {
-  setReturnToFromReferer(req)
   passport.authenticate('twitter')(req, res, next)
 })
 

--- a/lib/web/auth/utils.js
+++ b/lib/web/auth/utils.js
@@ -3,12 +3,6 @@
 const models = require('../../models')
 const logger = require('../../logger')
 
-exports.setReturnToFromReferer = function setReturnToFromReferer (req) {
-  var referer = req.get('referer')
-  if (!req.session) req.session = {}
-  req.session.returnTo = referer
-}
-
 exports.passportGeneralCallback = function callback (accessToken, refreshToken, profile, done) {
   var stringifiedProfile = JSON.stringify(profile)
   models.User.findOrCreate({


### PR DESCRIPTION
Saving referer into session in SAML auth so passport can redirect correctly after SAML login.
Before this, after the SAML login the user was always redirected to config.serverURL + '/'

Signed-off-by: Ralph Krimmel <rkrimme1@gwdg.de>