### PR TITLE
Fix #234 - make manage_users work again

### DIFF
--- a/bin/manage_users
+++ b/bin/manage_users
@@ -36,9 +36,9 @@ function getPass(argv, action) {
 async function createUser(argv) {
 	const existing_user = await models.User.findOne({where: {email: argv["add"]}});
 	// Cannot create already-existing users
-	if(existing_user != undefined) {
+	if(existing_user) {
 		console.log(`User with e-mail ${existing_user.email} already exists! Aborting ...`);
-		process.exit(1);
+		process.exit(2);
 	}
 
 	const pass = getPass(argv, "add");
@@ -57,7 +57,7 @@ async function createUser(argv) {
 async function deleteUser(argv) {
 	// Cannot delete non-existing users
 	const existing_user = await models.User.findOne({where: {email: argv["del"]}});
-	if(existing_user === undefined) {
+	if(!existing_user) {
 		console.log(`User with e-mail ${argv["del"]} does not exist, cannot delete`);
 		process.exit(1);
 	}
@@ -73,7 +73,7 @@ async function deleteUser(argv) {
 async function resetUser(argv) {
 	const existing_user = await models.User.findOne({where: {email: argv["reset"]}});
 	// Cannot reset non-existing users
-	if(existing_user == undefined) {
+	if(!existing_user) {
 		console.log(`User with e-mail ${argv["reset"]} does not exist, cannot reset`);
 		process.exit(1);
 	}


### PR DESCRIPTION
Fixes #234 

The manage_users script currently does not work since it compares to undefined. However, the returned variable is null, resulting in crashing of the script. (see #234)

Additionally, I changed a return code in the createUser() function. This allows other scripts to distinguish between the failure reasons.

This pull request was created a couple days ago on the other CodiMD project: https://github.com/hackmdio/codimd/pull/1370