### PR TITLE
[DOC] Point out that `urlPath/CMD_URL_PATH` option might be broken.

### DIFF
--- a/docs/configuration-config-file.md
+++ b/docs/configuration-config-file.md
@@ -60,7 +60,7 @@ these are rarely used for various reasons.
 | variables | example values | description |
 | --------- | ------ | ----------- |
 | `domain` | `localhost` | domain name |
-| `urlPath` | `codimd` | sub URL path, like `www.example.com/<urlpath>` |
+| `urlPath` | `codimd` | sub URL path, like `www.example.com/<urlpath>`. DEPRECATED, might not work correctly. |
 | `host` | `localhost` | interface/ip to listen on |
 | `port` | `80` | port to listen on |
 | `path` | `/var/run/codimd.sock` | path to UNIX domain socket to listen on (if specified, `host` and `port` are ignored) |

--- a/docs/configuration-env-vars.md
+++ b/docs/configuration-env-vars.md
@@ -43,7 +43,7 @@ defaultNotePath can't be set from env-vars
 | variable | example value | description |
 | -------- | ------------- | ----------- |
 | `CMD_DOMAIN` | `codimd.org` | domain name |
-| `CMD_URL_PATH` | `codimd` | If CodiMD is run from a subdirectory like `www.example.com/<urlpath>` |
+| `CMD_URL_PATH` | `codimd` | If CodiMD is run from a subdirectory like `www.example.com/<urlpath>`. DEPRECATED, might not work correctly. |
 | `CMD_HOST` | `localhost` | interface/ip to listen on |
 | `CMD_PORT` | `80` | port to listen on |
 | `CMD_PATH` | `/var/run/codimd.sock` | path to UNIX domain socket to listen on (if specified, `CMD_HOST` and `CMD_PORT` are ignored) |


### PR DESCRIPTION
It is in fact broken in current master and v1.5.0, see #105.