### PR TITLE
Fix urlPath support, let CodiMD be served from a subpath correctly

### DIFF
--- a/public/views/codimd/head.ejs
+++ b/public/views/codimd/head.ejs
@@ -12,6 +12,7 @@
 <meta property="og:image:alt" content="CodiMD logo">
 <meta property="og:image:type" content="image/png">
 <% } %>
+<base href="<%- serverURL %>/">
 <title><%= title %></title>
 <link rel="icon" type="image/png" href="<%- serverURL %>/favicon.png">
 <link rel="apple-touch-icon" href="<%- serverURL %>/apple-touch-icon.png">

--- a/public/views/includes/header.ejs
+++ b/public/views/includes/header.ejs
@@ -1,3 +1,3 @@
 <% for (var css in htmlWebpackPlugin.files.css) { %>
-<link href="<%= webpackConfig.output.baseUrl %><%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
+<link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet">
 <% } %>

--- a/public/views/includes/scripts.ejs
+++ b/public/views/includes/scripts.ejs
@@ -1,4 +1,4 @@
-<script src="<%= webpackConfig.output.baseUrl %>/config"></script>
+<script src="config"></script>
 <% for (var js in htmlWebpackPlugin.files.js) { %>
-<script src="<%= webpackConfig.output.baseUrl %><%= htmlWebpackPlugin.files.js[js] %>" defer></script>
+<script src="<%= htmlWebpackPlugin.files.js[js] %>" defer></script>
 <% } %>

--- a/public/views/index/head.ejs
+++ b/public/views/index/head.ejs
@@ -13,6 +13,7 @@
 <meta property="og:image" content="<%- serverURL %>/codimd-icon-1024.png">
 <meta property="og:image:alt" content="CodiMD logo">
 <meta property="og:image:type" content="image/png">
+<base href="<%- serverURL %>/">
 <title>CodiMD - <%= __('Collaborative markdown notes') %></title>
 <link rel="icon" type="image/png" href="<%- serverURL %>/favicon.png">
 <link rel="apple-touch-icon" href="<%- serverURL %>/apple-touch-icon.png">

--- a/public/views/pretty.ejs
+++ b/public/views/pretty.ejs
@@ -22,6 +22,7 @@
     <meta property="og:image:alt" content="CodiMD logo">
     <meta property="og:image:type" content="image/png">
     <% } %>
+    <base href="<%- serverURL %>/">
     <title><%= title %></title>
     <link rel="icon" type="image/png" href="<%- serverURL %>/favicon.png">
     <link rel="apple-touch-icon" href="<%- serverURL %>/apple-touch-icon.png">

--- a/public/views/slide.ejs
+++ b/public/views/slide.ejs
@@ -11,6 +11,7 @@
         <% if(typeof description !== 'undefined' && description) { %>
         <meta name="description" content="<%= description %>">
         <% } %>
+        <base href="<%- serverURL %>/">
         <title><%= title %></title>
         <link rel="icon" type="image/png" href="<%- serverURL %>/favicon.png">
         <link rel="apple-touch-icon" href="<%- serverURL %>/apple-touch-icon.png">

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -352,7 +352,7 @@ module.exports = {
 
   output: {
     path: path.join(__dirname, 'public/build'),
-    publicPath: '/build/',
+    publicPath: 'build/',
     filename: '[name].js'
   },
 

--- a/webpack.htmlexport.js
+++ b/webpack.htmlexport.js
@@ -14,7 +14,7 @@ module.exports = {
   },
   output: {
     path: path.join(__dirname, 'public/build'),
-    publicPath: '/build/',
+    publicPath: 'build/',
     filename: '[name].js'
   },
   plugins: [

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -9,7 +9,7 @@ module.exports = [
     mode: 'production',
     output: {
       path: path.join(__dirname, 'public/build'),
-      publicPath: '/build/',
+      publicPath: 'build/',
       filename: '[name].[contenthash].js'
     }
   }),


### PR DESCRIPTION
Webpack now uses relative paths for resources linked from by static
snippets. A templated <base> tag has been introduced in headers
so app.js can set the base URL at runtime.

EDIT: this fixes #105 