### PR TITLE
[DOC] Run `manage_users` with `NODE_ENV=production` set.

### DIFF
--- a/docs/configuration-config-file.md
+++ b/docs/configuration-config-file.md
@@ -104,7 +104,7 @@ these are rarely used for various reasons.
 | variables | example values | description |
 | --------- | ------ | ----------- |
 | `email` | `true` or `false` | Set to allow email sign-in. The default is `true`. |
-| `allowEmailRegister`  | `true` or `false` | Set to allow registration of new accounts using an email address. If set to `false`, you can still create accounts using the command line - see `bin/manage_users` for details. This setting has no effect if `email` is `false`. The default for `allowEmailRegister` is `true`. |
+| `allowEmailRegister`  | `true` or `false` | Set to allow registration of new accounts using an email address. If set to `false`, you can still create accounts using the command line - see `bin/manage_users` for details (In production mode, remember to run it with `NODE_ENV` set as `production` in the enviroment). This setting has no effect if `email` is `false`. The default for `allowEmailRegister` is `true`. |
 
 ### Dropbox Login
 

--- a/docs/configuration-env-vars.md
+++ b/docs/configuration-env-vars.md
@@ -91,7 +91,7 @@ defaultNotePath can't be set from env-vars
 | variable | example value | description |
 | -------- | ------------- | ----------- |
 | `CMD_EMAIL` | `true` or `false` | Set to allow email sign-in. The default is `true`. |
-| `CMD_ALLOW_EMAIL_REGISTER` | `true` or `false` | Set to allow registration of new accounts using an email address. If set to `false`, you can still create accounts using the command line - see `bin/manage_users` for details. This setting has no effect if `CMD_EMAIL` is `false`. The default for `CMD_ALLOW_EMAIL_REGISTER` is `true`. |
+| `CMD_ALLOW_EMAIL_REGISTER` | `true` or `false` | Set to allow registration of new accounts using an email address. If set to `false`, you can still create accounts using the command line - see `bin/manage_users` for details (In production mode, remember to run it with `NODE_ENV` set as `production` in the enviroment). This setting has no effect if `CMD_EMAIL` is `false`. The default for `CMD_ALLOW_EMAIL_REGISTER` is `true`. |
 
 
 ### Dropbox Login


### PR DESCRIPTION
`manage_user` script defaults to `development` environment.
Add to doc the solution suggested by @SISheogorath in #148 . 