### PR TITLE
Fix #249 - Focus user field after opening login modal

### DIFF
--- a/public/js/cover.js
+++ b/public/js/cover.js
@@ -428,3 +428,17 @@ $('.ui-use-tags').on('change', function () {
 $('.search').keyup(() => {
   checkHistoryList()
 })
+
+// focus user field after opening login modal
+$('.signin-modal').on('shown.bs.modal', function () {
+  let fieldLDAP = $('input[name=username]')
+  let fieldEmail = $('input[name=email]')
+  let fieldOpenID = $('input[name=openid_identifier]')
+  if (fieldLDAP.length === 1) {
+    fieldLDAP.focus()
+  } else if (fieldEmail.length === 1) {
+    fieldEmail.focus()
+  } else if (fieldOpenID.length === 1) {
+    fieldOpenID.focus()
+  }
+})


### PR DESCRIPTION
When the login dialog is opened, the focus will be set to either the LDAP-username field, the email field or the OpenID field in this order.