### PR TITLE
Changed Gravatar to Libravatar in privacy-template

### DIFF
--- a/public/docs/privacy.md.example
+++ b/public/docs/privacy.md.example
@@ -5,9 +5,9 @@ We process the following data, for the following purposes:
 
 |your data|our usage|
 |---------|---------|
-|IP-Address|Used to communicate with your browser and our servers. It's may exposed to third-parties which provide resources for this service. These services are, depending on your login method, the document you visit and the setup of this instance: Google, Disqus, MathJax, GitHub, SlideShare/LinkedIn, yahoo, Gravatar, Imgur, Amazon, and Cloudflare.|
+|IP-Address|Used to communicate with your browser and our servers. It's may exposed to third-parties which provide resources for this service. These services are, depending on your login method, the document you visit and the setup of this instance: Google, Disqus, MathJax, GitHub, SlideShare/LinkedIn, yahoo, Libravatar, Imgur, Amazon, and Cloudflare.|
 |Usernames and profiles|Your username as well as user profiles that are connected with it are transmitted and stored by us to provide a useful login integration with services like GitHub, Facebook, Twitter, GitLab, Dropbox, Google. Depending on the setup of this CodiMD instance there are maybe other third-parties involved using SAML, LDAP or the integration with a Mattermost instance.|
-|Profile pictures| Your profile picture is either loaded from the service you used to login, the CodiMD instance or Gravatar.|
+|Profile pictures| Your profile picture is either loaded from the service you used to login, the CodiMD instance or Libravatar.|
 |Uploaded pictures| Pictures that are uploaded for documents are either uploaded to Amazon S3, Imgur, a minio instance or the local filesystem of the CodiMD server.|
 
 All account data and notes are stored in a mysql/postgres/sqlite database. Besides the user accounts and the document themselves also relationships between the documents and the user accounts are stored. This includes ownership, authorship and revisions of all changes made during the creation of a note.


### PR DESCRIPTION
Very tiny PR: In #173 the documentation was updated regarding the usage of Libravatar instead of Gravatar. This PR does the update for the privacy template document.

Btw: The privacy statement at demo.codimd.org still refers to Gravatar too.