### PR TITLE
Add config option to make a domain restriction for google OAuth 

### DIFF
--- a/app.json
+++ b/app.json
@@ -132,6 +132,10 @@
             "description": "Google API client secret",
             "required": false
         },
+        "CMD_GOOGLE_HOSTEDDOMAIN": {
+            "description": "Google API hosted domain (Provided only if the user belongs to a hosted domain)",
+            "required": false
+        },
         "CMD_IMGUR_CLIENTID": {
             "description": "Imgur API client id",
             "required": false

--- a/docs/configuration-config-file.md
+++ b/docs/configuration-config-file.md
@@ -134,7 +134,7 @@ these are rarely used for various reasons.
 
 | variables | example values | description |
 | --------- | ------ | ----------- |
-| `google` | `{clientID: ..., clientSecret: ...}` | An object containing the client ID and the client secret obtained by the [Google API console](https://console.cloud.google.com/apis) |
+| `google` | `{clientID: ..., clientSecret: ..., hostedDomain: ...}` | An object containing the client ID and the client secret obtained by the [Google API console](https://console.cloud.google.com/apis) |
 
 ### LDAP Login
 

--- a/docs/configuration-env-vars.md
+++ b/docs/configuration-env-vars.md
@@ -135,6 +135,7 @@ defaultNotePath can't be set from env-vars
 | -------- | ------------- | ----------- |
 | `CMD_GOOGLE_CLIENTID` | no example | Google API client id |
 | `CMD_GOOGLE_CLIENTSECRET` | no example | Google API client secret |
+| `CMD_GOOGLE_HOSTEDDOMAIN` | `example.com` | Provided only if the user belongs to a hosted domain. default is `undefined` |
 
 
 ### LDAP Login

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -124,7 +124,8 @@ module.exports = {
   },
   google: {
     clientID: undefined,
-    clientSecret: undefined
+    clientSecret: undefined,
+    hostedDomain: undefined
   },
   ldap: {
     providerName: undefined,

--- a/lib/config/dockerSecret.js
+++ b/lib/config/dockerSecret.js
@@ -53,7 +53,8 @@ if (fs.existsSync(basePath)) {
     },
     google: {
       clientID: getSecret('google_clientID'),
-      clientSecret: getSecret('google_clientSecret')
+      clientSecret: getSecret('google_clientSecret'),
+      hostedDomain: getSecret('google_hostedDomain')
     },
     imgur: getSecret('imgur_clientid')
   }

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -101,7 +101,8 @@ module.exports = {
   },
   google: {
     clientID: process.env.CMD_GOOGLE_CLIENTID,
-    clientSecret: process.env.CMD_GOOGLE_CLIENTSECRET
+    clientSecret: process.env.CMD_GOOGLE_CLIENTSECRET,
+    hostedDomain: process.env.CMD_GOOGLE_HOSTEDDOMAIN
   },
   ldap: {
     providerName: process.env.CMD_LDAP_PROVIDERNAME,

--- a/lib/web/auth/google/index.js
+++ b/lib/web/auth/google/index.js
@@ -16,7 +16,7 @@ passport.use(new GoogleStrategy({
 }, passportGeneralCallback))
 
 googleAuth.get('/auth/google', function (req, res, next) {
-  passport.authenticate('google', { scope: ['profile'] })(req, res, next)
+  passport.authenticate('google', { scope: ['profile'], hostedDomain: config.google.hostedDomain })(req, res, next)
 })
 // google auth callback
 googleAuth.get('/auth/google/callback',

--- a/yarn.lock
+++ b/yarn.lock
@@ -10637,10 +10637,10 @@ retry-as-promised@^3.2.0:
   dependencies:
     any-promise "^1.3.0"
 
-reveal.js@~3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/reveal.js/-/reveal.js-3.7.0.tgz#7afaf72fd963000381289d58f3aa54c0c46b150c"
-  integrity sha512-HTOTNhF5mQAw6fcsptk4oql/DEEUwTG0YHk/LzTNNx0/3IgvOQZqKzvlK/zNpqqKMLlhn1gH9Nvp+FFoc/e5/w==
+reveal.js@~3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/reveal.js/-/reveal.js-3.9.2.tgz#7f63d3dfec338b6c313dcabdf006e8cf80e0b358"
+  integrity sha512-Dvv2oA9FrtOHE2DWj5js8pMRfwq++Wmvsn1EyAdYLC80lBjTphns+tPsB652Bnvep9AVviuVS/b4XoVY9rXHLA==
 
 rgb-regex@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Hi, I currently using it for company level knowledge sharing, and I would like to force users to log in from Google OAuth using our own domain.

So I make a patch on 
```
- passport.authenticate('google', { scope: ['profile'] })(req, res, next)
+ passport.authenticate('google', { scope: ['profile'], hostedDomain: config.google.hostedDomain })(req, res, next)
```
and configuration setups.

I hope that makes sense.

I also update the `yarn.lock` within MR, cause I found there was a build failed when I deploy on Heroku due to `package.json` was updated.