### PR TITLE
Update CDN defaults

### DIFF
--- a/docs/configuration-config-file.md
+++ b/docs/configuration-config-file.md
@@ -82,7 +82,7 @@ these are rarely used for various reasons.
 | variables | example values | description |
 | --------- | ------ | ----------- |
 | `allowGravatar` | `true` or `false` | set to `false` to disable [Libravatar](https://www.libravatar.org/) as profile picture source on your instance. Libravatar is a federated open-source alternative to Gravatar. |
-| `useCDN` | `true` or `false` | set to use CDN resources or not (default is `true`) |
+| `useCDN` | `true` or `false` | set to use CDN resources or not (default is `false`) |
 
 ## Users and Privileges
 

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -28,7 +28,7 @@ module.exports = {
     reportURI: undefined
   },
   protocolUseSSL: false,
-  useCDN: true,
+  useCDN: false,
   allowAnonymous: true,
   allowAnonymousEdits: false,
   allowFreeURL: false,


### PR DESCRIPTION
As we noticed in our poll about CDN usage, that most people
intentionally turn it off, but very little intetionally turn it on or
leave it on. https://community.codimd.org/t/poll-on-cdn-usage/28

There is also strong indicators that CDNs don't really provide any
benefits in loading time and due to the small deployments of CodiMD,
there is no big savings due to CDNs either. https://csswizardry.com/2019/05/self-host-your-static-assets/

Therefore this patch changes the CDN default settings to off in order to
reduce the exposed user data.