### PR TITLE
Fix revision redirect to index page

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1103,7 +1103,7 @@ function parseRevisions (_revisions) {
     revisionList.html('')
     for (var i = 0; i < revisions.length; i++) {
       var revision = revisions[i]
-      var item = $('<a href="#" class="list-group-item"></a>')
+      var item = $('<a class="list-group-item"></a>')
       item.attr('data-revision-time', revision.time)
       if (lastRevision === revision.time) item.addClass('active')
       var itemHeading = $('<h5 class="list-group-item-heading"></h5>')


### PR DESCRIPTION
The revision view had a bug that clicking on a list entry would redirect
the user back to the index page instead of providing the revision diff.

This was cased by the baseurl which is now used as reference for hrefs.
Therefore when clicking on the `href="#"` this was actually pointing at
`<baseurl>#` which is usually the index page.

This patch simply removes the href from the list items and therefore the
link functionality. This fixes the whole problem by removing 9
characters from our source code