### PR TITLE
Fix broken redirect on login

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -7,7 +7,7 @@ module.exports = {
       responseError(res, '403', 'Forbidden', 'oh no.')
     } else {
       if (!req.session) req.session = {}
-      req.session.returnTo = req.originalUrl || config.serverUrl + '/'
+      req.session.returnTo = config.serverURL + (req.originalUrl || '/')
       req.flash('error', 'You are not allowed to access this page. Maybe try logging in?')
       res.redirect(config.serverURL + '/')
     }


### PR DESCRIPTION
This patch fixes the currently broken redirect on login when people try
to access a site they have no access to, they are redirected to the main
page to log in. After a successful login they should be redirected to
the original note, but instead are redirect to the index page again.

This aptch fixes the typo that causes the behavior and brings people
back to the note they edited.

Thanks to @clvs7-gh on Github, who submitted the patch via email.

On their behalf I hereby submit the change.

Fixes #272 and fixes #273 