### PR TITLE
Limit DB schema changes to migrations

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -254,7 +254,7 @@ function startListen () {
 }
 
 // sync db then start listen
-models.sequelize.sync().then(function () {
+models.sequelize.authenticate().then(function () {
   // check if realtime is ready
   if (realtime.isReady()) {
     models.Revision.checkAllNotesRevision(function (err, notes) {


### PR DESCRIPTION
Database migrations should be in charge of changing and modifying the
database schema. Therefore this breaking change removes the automatic
model synchronisation from the application startup, that we have
practised way too long and that always caused problems for us.