### PR TITLE
Pass through ldap starttls option

### DIFF
--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -133,7 +133,8 @@ module.exports = {
     searchAttributes: undefined,
     usernameField: undefined,
     useridField: undefined,
-    tlsca: undefined
+    tlsca: undefined,
+    starttls: undefined
   },
   saml: {
     idpSsoUrl: undefined,

--- a/lib/web/auth/ldap/index.js
+++ b/lib/web/auth/ldap/index.js
@@ -19,7 +19,8 @@ passport.use(new LDAPStrategy({
     searchBase: config.ldap.searchBase || null,
     searchFilter: config.ldap.searchFilter || null,
     searchAttributes: config.ldap.searchAttributes || null,
-    tlsOptions: config.ldap.tlsOptions || null
+    tlsOptions: config.ldap.tlsOptions || null,
+    starttls: config.ldap.starttls || null
   }
 }, function (user, done) {
   var uuid = user.uidNumber || user.uid || user.sAMAccountName || undefined

--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
   "resolutions": {
     "**/tough-cookie": "~2.4.0",
     "**/minimatch": "^3.0.2",
-    "**/request": "^2.88.0"
+    "**/request": "^2.88.0",
+    "**/ldapauth-fork": "^4.3.0"
   },
   "engines": {
     "node": ">=8.x"


### PR DESCRIPTION
This makes it possible to use StartTLS by passing the starttls option through to the passport-ldapauth library. This resolves Issue #329
