### PR TITLE
Fixed eslint error introduced by 2d3ea1f

### DIFF
--- a/public/js/lib/editor/index.js
+++ b/public/js/lib/editor/index.js
@@ -269,7 +269,6 @@ export default class Editor {
     makeDiagramAbcMusic.click(() => {
       utils.insertText(this.editor, '```abc\nX:1\nT:Speed the Plough\nM:4/4\nC:Trad.\nK:G\n|:GABc dedB|dedB dedB|c2ec B2dB|c2A2 A2BA|\nGABc dedB|dedB dedB|c2ec B2dB|A2F2 G4:|\n|:g2gf gdBd|g2f2 e2d2|c2ec B2dB|c2A2 A2df|\ng2gf g2Bd|g2f2 e2d2|c2ec B2dB|A2F2 G4:|\n```\n')
     })
-
   }
 
   addStatusBar () {


### PR DESCRIPTION
Several of the last travis-ci builds failed due to a useless blank line being detected by eslint.
This PR is just to make eslint happy again - so that new builds run without problems.