### PR TITLE
Fixed wrong locales search path after app.js move

### DIFF
--- a/docs/configuration-config-file.md
+++ b/docs/configuration-config-file.md
@@ -52,6 +52,7 @@ these are rarely used for various reasons.
 | `docsPath` | `./public/docs` | docs directory path<sup>1</sup> |
 | `viewPath` | `./public/views` | template directory path<sup>1</sup> |
 | `uploadsPath` | `./public/uploads` | uploads directory<sup>1</sup> - needs to be persistent when you use imageUploadType `filesystem` |
+| `localesPath` | `./locales` | directory for translations<sup>1</sup> |
 
 
 ## CodiMD Location

--- a/lib/app.js
+++ b/lib/app.js
@@ -116,7 +116,7 @@ i18n.configure({
   locales: ['en', 'zh-CN', 'zh-TW', 'fr', 'de', 'ja', 'es', 'ca', 'el', 'pt', 'it', 'tr', 'ru', 'nl', 'hr', 'pl', 'uk', 'hi', 'sv', 'eo', 'da', 'ko', 'id', 'sr', 'vi', 'ar', 'cs', 'sk'],
   cookie: 'locale',
   indent: '    ', // this is the style poeditor.com exports it, this creates less churn
-  directory: path.join(__dirname, '/locales'),
+  directory: path.join(__dirname, '../locales'),
   updateFiles: config.updateI18nFiles
 })
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -116,7 +116,7 @@ i18n.configure({
   locales: ['en', 'zh-CN', 'zh-TW', 'fr', 'de', 'ja', 'es', 'ca', 'el', 'pt', 'it', 'tr', 'ru', 'nl', 'hr', 'pl', 'uk', 'hi', 'sv', 'eo', 'da', 'ko', 'id', 'sr', 'vi', 'ar', 'cs', 'sk'],
   cookie: 'locale',
   indent: '    ', // this is the style poeditor.com exports it, this creates less churn
-  directory: path.join(__dirname, '../locales'),
+  directory: path.resolve(__dirname, config.localesPath),
   updateFiles: config.updateI18nFiles
 })
 

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -48,6 +48,7 @@ module.exports = {
   defaultNotePath: './public/default.md',
   docsPath: './public/docs',
   uploadsPath: './public/uploads',
+  localesPath: './locales',
   // session
   sessionName: 'connect.sid',
   sessionSecret: 'secret',

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -201,6 +201,7 @@ config.publicPath = path.resolve(appRootPath, config.publicPath)
 config.defaultNotePath = path.resolve(appRootPath, config.defaultNotePath)
 config.docsPath = path.resolve(appRootPath, config.docsPath)
 config.uploadsPath = path.resolve(appRootPath, config.uploadsPath)
+config.localesPath = path.resolve(appRootPath, config.localesPath)
 
 // make config readonly
 config = deepFreeze(config)


### PR DESCRIPTION
The locales search path needs to be updated because the main app.js was moved into a sub-directory (/lib).