### PR TITLE
Add 'nofooter' option for slide presentation mode

### DIFF
--- a/public/js/slide.js
+++ b/public/js/slide.js
@@ -137,3 +137,8 @@ Reveal.addEventListener('slidechanged', renderSlide)
 const isWinLike = navigator.platform.indexOf('Win') > -1
 
 if (isWinLike) $('.container').addClass('hidescrollbar')
+
+if (window.location.search.match(/.*[?&]nofooter(?:&.*)?$/)) {
+  $('.footer').addClass('hidden')
+  $('.container').addClass('hidescrollbar')
+}


### PR DESCRIPTION
The slide presentation mode has a footer with metadata about the presentation that optionally may host disqus. If you scroll down by accident in a presentation, the footer might be irritating.
This PR adds a new option "nofooter" that may be added as a parameter to the URL.
So when "?nofooter" (or "?anythingelse&nofooter") is applied to the URL, the footer will be hidden.

Fixes #88 