### PR TITLE
Add night mode detection

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -446,8 +446,15 @@ $(document).ready(function () {
     })
   }
 
+  // Use the new CSS selector for dark theme requests to automatically turn on night mode
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
+  let darkTheme = window.matchMedia("(prefers-color-scheme: dark)")
   // Re-enable nightmode
-  if (store.get('nightMode') || Cookies.get('nightMode')) {
+  let storageNightMode = store.get('nightMode')
+  let cookiesNightMode = Cookies.get('nightMode')
+
+  if (storageNightMode || cookiesNightMode ||
+   ((typeof storageNightMode !== "boolean" && typeof cookiesNightMode !== "boolean") && darkTheme.matches)) {
     $body.addClass('night')
     ui.toolbar.night.addClass('active')
   }


### PR DESCRIPTION
Firefox and Safari power a new CSS media query which allows to detect
user's dark mode. This patch adds a JS implementation that toggles the
our night mode automatically when a user's theme requests a dark mode.

Resources:
https://hacks.mozilla.org/2019/05/firefox-67-dark-mode-css-webrender/
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme