### PR TITLE
findNoteOrCreate: Create new note with empty string instead of `null`

### DIFF
--- a/lib/web/note/util.ts
+++ b/lib/web/note/util.ts
@@ -22,7 +22,7 @@ export module NoteUtils {
         }
       }).then(function (note) {
         if (!note) {
-          return newNote(req, res, null)
+          return newNote(req, res, "")
         }
         if (!checkViewPermission(req, note)) {
           return errors.errorForbidden(res)


### PR DESCRIPTION
Fixes #343 

Signed-off-by: David Mehren <dmehren1@gmail.com>