### PR TITLE
findNoteOrCreate: Create new note with empty string instead of `null`

### DIFF
--- a/lib/web/note/util.js
+++ b/lib/web/note/util.js
@@ -19,7 +19,7 @@ exports.findNote = function (req, res, callback, include) {
       include: include || null
     }).then(function (note) {
       if (!note) {
-        return exports.newNote(req, res, null)
+        return exports.newNote(req, res, '')
       }
       if (!exports.checkViewPermission(req, note)) {
         return errors.errorForbidden(res)


### PR DESCRIPTION
Backport of #345 to 1.x

Closes #343

Edit:
Not sure what Travis is doing and why there is a 3rd check for it also I accidentally pushed into the repo and not my fork. Hope this is no problem.