### PR TITLE
Tests and Fixes for Auth Middlewares

### DIFF
--- a/lib/letter-avatars.ts
+++ b/lib/letter-avatars.ts
@@ -25,9 +25,6 @@ export function generateAvatar (name: string): string {
 
 export function generateAvatarURL (name: string, email = '', big = true): string {
   let photo
-  if (email.length === 0) {
-    email = '' + name + '@example.com'
-  }
   name = encodeURIComponent(name)
 
   const hash = createHash('md5')

--- a/lib/models/user.ts
+++ b/lib/models/user.ts
@@ -36,7 +36,7 @@ export type Profile = {
   id: string;
   username: string;
   displayName: string;
-  emails: any[];
+  emails: string[];
   avatarUrl: string;
   profileUrl: string;
   provider: ProviderEnum;
@@ -125,7 +125,7 @@ export class User extends Model<User> {
         }
         break
       case ProviderEnum.dropbox:
-        photo = generateAvatarURL('', profile.emails[0].value, bigger)
+        photo = generateAvatarURL('', profile.emails[0], bigger)
         break
       case ProviderEnum.google:
         photo = profile.photos[0].value

--- a/lib/web/auth/dropbox/index.ts
+++ b/lib/web/auth/dropbox/index.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response, Router } from 'express'
 import passport from 'passport'
-import * as DropboxStrategy from 'passport-dropbox-oauth2'
+import { Strategy as DropboxStrategy } from 'passport-dropbox-oauth2'
 import { config } from '../../../config'
 import { AuthMiddleware } from '../interface'
 import { passportGeneralCallback } from '../utils'

--- a/lib/web/auth/dropbox/index.ts
+++ b/lib/web/auth/dropbox/index.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response, Router } from 'express'
 import passport from 'passport'
 import { Strategy as DropboxStrategy } from 'passport-dropbox-oauth2'
 import { config } from '../../../config'
+import { User } from '../../../models'
 import { AuthMiddleware } from '../interface'
 import { passportGeneralCallback } from '../utils'
 
@@ -14,7 +15,17 @@ export const DropboxMiddleware: AuthMiddleware = {
       clientID: config.dropbox.clientID,
       clientSecret: config.dropbox.clientSecret,
       callbackURL: config.serverURL + '/auth/dropbox/callback'
-    }, passportGeneralCallback))
+    }, (
+      accessToken: string,
+      refreshToken: string,
+      profile: any,
+      done: (err?: Error | null, user?: User) => void
+    ): void => {
+      // the Dropbox plugin wraps the email addresses in an object
+      // see https://github.com/florianheinemann/passport-dropbox-oauth2/blob/master/lib/passport-dropbox-oauth2/strategy.js#L146
+      profile.emails = profile.emails.map(element => element.value)
+      passportGeneralCallback(accessToken, refreshToken, profile, done)
+    }))
 
     dropboxAuth.get('/auth/dropbox', function (req: Request, res: Response, next: NextFunction) {
       passport.authenticate('dropbox-oauth2')(req, res, next)

--- a/test/auth.ts
+++ b/test/auth.ts
@@ -1,0 +1,110 @@
+import assert from 'assert'
+import { ImportMock } from 'ts-mock-imports'
+import * as configModule from '../lib/config'
+import { DropboxMiddleware } from '../lib/web/auth/dropbox'
+import { EmailMiddleware } from '../lib/web/auth/email'
+import { FacebookMiddleware } from '../lib/web/auth/facebook'
+import { GithubMiddleware } from '../lib/web/auth/github'
+import { GitlabMiddleware } from '../lib/web/auth/gitlab'
+import { GoogleMiddleware } from '../lib/web/auth/google'
+import { LdapMiddleware } from '../lib/web/auth/ldap'
+import { OAuth2Middleware } from '../lib/web/auth/oauth2'
+import { OPenIDMiddleware } from '../lib/web/auth/openid'
+import { TwitterMiddleware } from '../lib/web/auth/twitter'
+
+describe('AuthMiddlewares', function () {
+  // We currently exclude the SAML Auth, because it needs a certificate file
+  const middlewareList = [{
+    name: 'Facebook',
+    middleware: FacebookMiddleware,
+    config: {
+      facebook: {
+        clientID: 'foobar',
+        clientSecret: 'foobar'
+      }
+    }
+  }, {
+    name: 'Twitter',
+    middleware: TwitterMiddleware,
+    config: {
+      twitter: {
+        consumerKey: 'foobar',
+        consumerSecret: 'foobar'
+      }
+    }
+  }, {
+    name: 'GitHub',
+    middleware: GithubMiddleware,
+    config: {
+      github: {
+        clientID: 'foobar',
+        clientSecret: 'foobar'
+      }
+    }
+  }, {
+    name: 'Gitlab',
+    middleware: GitlabMiddleware,
+    config: {
+      gitlab: {
+        clientID: 'foobar',
+        clientSecret: 'foobar'
+      }
+    }
+  }, {
+    name: 'Dropbox',
+    middleware: DropboxMiddleware,
+    config: {
+      dropbox: {
+        clientID: 'foobar',
+        clientSecret: 'foobar'
+      }
+    }
+  }, {
+    name: 'Google',
+    middleware: GoogleMiddleware,
+    config: {
+      google: {
+        clientID: 'foobar',
+        clientSecret: 'foobar'
+      }
+    }
+  }, {
+    name: 'LDAP',
+    middleware: LdapMiddleware,
+    config: {
+      ldap: {}
+    }
+  }, {
+    name: 'OAuth2',
+    middleware: OAuth2Middleware,
+    config: {
+      oauth2: {
+        clientID: 'foobar',
+        clientSecret: 'foobar',
+        authorizationURL: 'foobar',
+        tokenURL: 'foobar',
+        userProfileURL: 'foobar',
+        scope: 'foobar'
+      }
+    }
+  }, {
+    name: 'Email',
+    middleware: EmailMiddleware,
+    config: {}
+  }, {
+    name: 'OpenID',
+    middleware: OPenIDMiddleware,
+    config: {}
+  }]
+
+  middlewareList.forEach((middleware) => {
+    describe(middleware.name + 'Middleware', () => {
+      before(() => {
+        ImportMock.mockOther(configModule, 'config', middleware.config)
+      })
+      it('can be instantiated', () => {
+        assert.ok(middleware.middleware.getMiddleware())
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR fixes a bug in the Dropbox auth middleware (broken import) and adds tests to make sure we avoid this type of bug in the future.

It also removes the custom handling of the Dropbox profile object in `parsePhotoByProfile`. The mail-address is now unwrapped in the `DropboxMiddleware` and `Profile.mail` is always a `string[]`.

Finally as `email` is always a string, we can get rid of a (broken) check in `generateAvatarURL`.

I tried to follow @SISheogorath s example and wrote longer commit messages to explain the changes :wink: 