### PR TITLE
Cookie cleanups

### DIFF
--- a/app.js
+++ b/app.js
@@ -139,7 +139,8 @@ app.use(session({
   saveUninitialized: true, // always create session to ensure the origin
   rolling: true, // reset maxAge on every response
   cookie: {
-    maxAge: config.sessionLife
+    maxAge: config.sessionLife,
+    sameSite: 'strict'
   },
   store: sessionStore
 }))

--- a/app.js
+++ b/app.js
@@ -57,7 +57,7 @@ app.use(morgan('combined', {
 }))
 
 // socket io
-var io = require('socket.io')(server)
+var io = require('socket.io')(server, { cookie: false })
 io.engine.ws = new (require('ws').Server)({
   noServer: true,
   perMessageDeflate: false

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1596,7 +1596,8 @@ function toggleNightMode () {
     store.set('nightMode', !isActive)
   } else {
     Cookies.set('nightMode', !isActive, {
-      expires: 365
+      expires: 365,
+      sameSite: 'strict'
     })
   }
 }

--- a/public/js/lib/common/login.js
+++ b/public/js/lib/common/login.js
@@ -19,11 +19,13 @@ export function resetCheckAuth () {
 
 export function setLoginState (bool, id) {
   Cookies.set('loginstate', bool, {
-    expires: 365
+    expires: 365,
+    sameSite: 'strict'
   })
   if (id) {
     Cookies.set('userid', id, {
-      expires: 365
+      expires: 365,
+      sameSite: 'strict'
     })
   } else {
     Cookies.remove('userid')

--- a/public/js/lib/editor/index.js
+++ b/public/js/lib/editor/index.js
@@ -303,12 +303,14 @@ export default class Editor {
     const setType = () => {
       if (this.editor.getOption('indentWithTabs')) {
         Cookies.set('indent_type', 'tab', {
-          expires: 365
+          expires: 365,
+          sameSite: 'strict'
         })
         type.text('Tab Size:')
       } else {
         Cookies.set('indent_type', 'space', {
-          expires: 365
+          expires: 365,
+          sameSite: 'strict'
         })
         type.text('Spaces:')
       }
@@ -319,11 +321,13 @@ export default class Editor {
       var unit = this.editor.getOption('indentUnit')
       if (this.editor.getOption('indentWithTabs')) {
         Cookies.set('tab_size', unit, {
-          expires: 365
+          expires: 365,
+          sameSite: 'strict'
         })
       } else {
         Cookies.set('space_units', unit, {
-          expires: 365
+          expires: 365,
+          sameSite: 'strict'
         })
       }
       widthLabel.text(unit)
@@ -391,7 +395,8 @@ export default class Editor {
     const setKeymapLabel = () => {
       var keymap = this.editor.getOption('keyMap')
       Cookies.set('keymap', keymap, {
-        expires: 365
+        expires: 365,
+        sameSite: 'strict'
       })
       label.text(keymap)
       this.restoreOverrideEditorKeymap()
@@ -439,7 +444,8 @@ export default class Editor {
       }
       this.editor.setOption('theme', theme)
       Cookies.set('theme', theme, {
-        expires: 365
+        expires: 365,
+        sameSite: 'strict'
       })
 
       checkTheme()
@@ -484,7 +490,8 @@ export default class Editor {
         this.editor.setOption('mode', mode)
       }
       Cookies.set('spellcheck', mode === 'spell-checker', {
-        expires: 365
+        expires: 365,
+        sameSite: 'strict'
       })
 
       checkSpellcheck()
@@ -529,7 +536,8 @@ export default class Editor {
     )
     if (overrideBrowserKeymap.is(':checked')) {
       Cookies.set('preferences-override-browser-keymap', true, {
-        expires: 365
+        expires: 365,
+        sameSite: 'strict'
       })
       this.restoreOverrideEditorKeymap()
     } else {

--- a/public/js/locale.js
+++ b/public/js/locale.js
@@ -25,7 +25,8 @@ $('select.ui-locale option[value="' + lang + '"]').attr('selected', 'selected')
 
 locale.change(function () {
   Cookies.set('locale', $(this).val(), {
-    expires: 365
+    expires: 365,
+    sameSite: 'strict'
   })
   window.location.reload()
 })


### PR DESCRIPTION
This disables the unneeded `io` cookie from socket.io and enables `sameSite: strict` for all cookies.