### PR TITLE
Ensure session cookies are secure

### DIFF
--- a/app.js
+++ b/app.js
@@ -139,7 +139,9 @@ app.use(session({
   saveUninitialized: true, // always create session to ensure the origin
   rolling: true, // reset maxAge on every response
   cookie: {
-    maxAge: config.sessionLife
+    maxAge: config.sessionLife,
+    sameSite: true,
+    secure: config.useSSL || config.protocolUseSSL || false
   },
   store: sessionStore
 }))

--- a/app.js
+++ b/app.js
@@ -57,7 +57,7 @@ app.use(morgan('combined', {
 }))
 
 // socket io
-var io = require('socket.io')(server)
+var io = require('socket.io')(server, {cookie: false})
 io.engine.ws = new (require('ws').Server)({
   noServer: true,
   perMessageDeflate: false


### PR DESCRIPTION
While HSTS should take care of most of this, setting cookies to be
secure, and only applied on same site helps to improve situations where
for whatever reason, downgrade attacks are still a thing.

This patch adds the `sameSite` and `secure` to the session cookie and
this way prevent all accidents where a browser may doesn't support HSTS
or HSTS is intentionally dropped.

Reference:
https://www.npmjs.com/package/express-session#cookiesecure