### PR TITLE
Fix allow anonymous edit documentation

### DIFF
--- a/docs/configuration-config-file.md
+++ b/docs/configuration-config-file.md
@@ -89,7 +89,7 @@ these are rarely used for various reasons.
 | variables | example values | description |
 | --------- | ------ | ----------- |
 | `allowAnonymous` | `true` or `false` | Set to allow anonymous usage (default is `true`). |
-| `allowAnonymousEdits` | `true` or `false` | If `allowAnonymous` is `true`: allow users to select `freely` permission, allowing guests to edit existing notes (default is `false`). |
+| `allowAnonymousEdits` | `true` or `false` | If `allowAnonymous` is `false`: allow users to select `freely` permission, allowing guests to edit existing notes (default is `false`). |
 | `allowFreeURL` | `true` or `false` | Set to allow new note creation by accessing a nonexistent note URL. This is the behavior familiar from [Etherpad](https://github.com/ether/etherpad-lite). |
 | `defaultPermission` | `freely`, `editable`, `limited`, `locked`, `protected` or `private` | Set notes default permission (only applied on signed-in users). |
 | `sessionName` | `connect.sid` | Cookie session name. |

--- a/docs/configuration-env-vars.md
+++ b/docs/configuration-env-vars.md
@@ -77,7 +77,7 @@ defaultNotePath can't be set from env-vars
 | variable | example value | description |
 | -------- | ------------- | ----------- |
 | `CMD_ALLOW_ANONYMOUS` | `true` or `false` | Set to allow anonymous usage (default is `true`). |
-| `CMD_ALLOW_ANONYMOUS_EDITS` | `true` or `false` | If `allowAnonymous` is `false`: allow users to select `freely` permission, allowing guests to edit existing notes (default is `true`). |
+| `CMD_ALLOW_ANONYMOUS_EDITS` | `true` or `false` | If `allowAnonymous` is `false`: allow users to select `freely` permission, allowing guests to edit existing notes (default is `false`). |
 | `CMD_ALLOW_FREEURL` | `true` or `false` | Set to allow new note creation by accessing a nonexistent note URL. This is the behavior familiar from [Etherpad](https://github.com/ether/etherpad-lite). |
 | `CMD_DEFAULT_PERMISSION` | `freely`, `editable`, `limited`, `locked`, `protected` or `private` | Set notes default permission (only applied on signed-in users). |
 | `CMD_SESSION_LIFE` | `1209600000` (14 days) | Cookie session life time in milliseconds. |


### PR DESCRIPTION
The default is false and the option only matters if allowAnonymous is false