### PR TITLE
Support setting scope and state in Generic OAuth2

### DIFF
--- a/docs/configuration-config-file.md
+++ b/docs/configuration-config-file.md
@@ -152,7 +152,7 @@ these are rarely used for various reasons.
 
 | variables | example values | description |
 | --------- | ------ | ----------- |
-| `oauth2` | `{baseURL: ..., userProfileURL: ..., userProfileUsernameAttr: ..., userProfileDisplayNameAttr: ..., userProfileEmailAttr: ..., tokenURL: ..., authorizationURL: ..., clientID: ..., clientSecret: ...}` | An object detailing your OAuth2 provider. Refer to the [Mattermost](guides/auth/mattermost-self-hosted.md) or [Nextcloud](guides/auth/nextcloud.md) examples for more details!|
+| `oauth2` | `{baseURL: ..., userProfileURL: ..., userProfileUsernameAttr: ..., userProfileDisplayNameAttr: ..., userProfileEmailAttr: ..., tokenURL: ..., authorizationURL: ..., clientID: ..., clientSecret: ..., state: ..., scope: ...}` | An object detailing your OAuth2 provider. Refer to the [Mattermost](guides/auth/mattermost-self-hosted.md) or [Nextcloud](guides/auth/nextcloud.md) examples for more details!|
 
 ### SAML Login
 

--- a/docs/configuration-env-vars.md
+++ b/docs/configuration-env-vars.md
@@ -176,6 +176,8 @@ defaultNotePath can't be set from env-vars
 | `CMD_OAUTH2_CLIENT_ID` | `afae02fckafd...` | you will get this from your OAuth2 provider when you register CodiMD as OAuth2-client, (no default value) |
 | `CMD_OAUTH2_CLIENT_SECRET` | `afae02fckafd...` | you will get this from your OAuth2 provider when you register CodiMD as OAuth2-client, (no default value) |
 | `CMD_OAUTH2_PROVIDERNAME` | `My institution` | Optional name to be displayed at login form indicating the oAuth2 provider |
+| `CMD_OAUTH2_SCOPE` | `openid profile email` | Scopes to be requested from OAuth2 provider |
+| `CMD_OAUTH2_STATE` | `true` or `false` | `true` to use a randomly generated state parameter when authenticating |
 
 
 ### SAML Login

--- a/lib/config/default.js
+++ b/lib/config/default.js
@@ -91,7 +91,9 @@ module.exports = {
     authorizationURL: undefined,
     tokenURL: undefined,
     clientID: undefined,
-    clientSecret: undefined
+    clientSecret: undefined,
+    scope: undefined,
+    state: false
   },
   facebook: {
     clientID: undefined,

--- a/lib/config/environment.js
+++ b/lib/config/environment.js
@@ -92,7 +92,9 @@ module.exports = {
     tokenURL: process.env.CMD_OAUTH2_TOKEN_URL,
     authorizationURL: process.env.CMD_OAUTH2_AUTHORIZATION_URL,
     clientID: process.env.CMD_OAUTH2_CLIENT_ID,
-    clientSecret: process.env.CMD_OAUTH2_CLIENT_SECRET
+    clientSecret: process.env.CMD_OAUTH2_CLIENT_SECRET,
+    scope: process.env.CMD_OAUTH2_SCOPE,
+    state: toBooleanConfig(process.env.CMD_OAUTH2_STATE)
   },
   dropbox: {
     clientID: process.env.CMD_DROPBOX_CLIENTID,

--- a/lib/web/auth/oauth2/index.js
+++ b/lib/web/auth/oauth2/index.js
@@ -89,7 +89,9 @@ passport.use(new OAuth2CustomStrategy({
   clientID: config.oauth2.clientID,
   clientSecret: config.oauth2.clientSecret,
   callbackURL: config.serverURL + '/auth/oauth2/callback',
-  userProfileURL: config.oauth2.userProfileURL
+  userProfileURL: config.oauth2.userProfileURL,
+  state: config.oauth2.state,
+  scope: config.oauth2.scope
 }, passportGeneralCallback))
 
 oauth2Auth.get('/auth/oauth2', function (req, res, next) {


### PR DESCRIPTION
The scope option lets us set a custom scope to retrieve the name, email
and username.

Setting a state protects against CSRF and is required by some OAuth2
providers (e.g. ORY Hydra)

Signed-off-by: Dexter Chua <dalcde@yahoo.com.hk>
