### PR TITLE
Generic OAuth2: Set state: true

### DIFF
--- a/src/lib/web/auth/oauth2/index.ts
+++ b/src/lib/web/auth/oauth2/index.ts
@@ -17,7 +17,8 @@ export const OAuth2Middleware: AuthMiddleware = {
       clientSecret: config.oauth2.clientSecret,
       callbackURL: config.serverURL + '/auth/oauth2/callback',
       userProfileURL: config.oauth2.userProfileURL,
-      scope: config.oauth2.scope
+      scope: config.oauth2.scope,
+      state: true
     }, passportGeneralCallback))
 
     OAuth2Auth.get('/auth/oauth2', passport.authenticate('oauth2'))


### PR DESCRIPTION
The OAuth2 specification RECOMMENDS setting the state to protect against
CSRF attacks. Some OAuth2 providers (e.g. ORY Hydra) refuse to
authenticate without the state set.

Signed-off-by: Dexter Chua <dalcde@yahoo.com.hk>