### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -98,7 +98,7 @@ app.use(morgan('combined', {
 if (config.hsts.enable) {
   app.use(helmet.hsts({
     maxAge: config.hsts.maxAgeSeconds,
-    includeSubdomains: config.hsts.includeSubdomains,
+    includeSubDomains: config.hsts.includeSubdomains,
     preload: config.hsts.preload
   }))
 } else if (config.useSSL) {


### PR DESCRIPTION
hsts deprecated The "includeSubdomains" parameter is deprecated. Use
"includeSubDomains" (with a capital D) instead. built/lib/app.js:95:30