### PR TITLE
Fix default permission

### DIFF
--- a/src/lib/models/note.ts
+++ b/src/lib/models/note.ts
@@ -170,7 +170,7 @@ export class Note extends Model<Note> {
       }
       // if no permission specified and have owner then give default permission in config, else default permission is freely
       if (!note.permission) {
-        if (note.owner) {
+        if (note.ownerId) {
           // TODO: Might explode if the user-defined permission does not exist
           note.permission = PermissionEnum[config.defaultPermission]
         } else {


### PR DESCRIPTION
When a logged in user creates a note, the `ownerId` is property is set,
but `owner` is not. Thus, the default note permission is always
`freely`, regardless of the `defaultPermission` setting. By checking
`ownerId` instead, this correctly uses the `defaultPermission` config
when the user is logged in.

This is especially an issue when `allowAnonymous` is `false`, since this
would allow the user to create a note with `freely` permission when it
should not be allowed.

It is unclear to me when `owner` is set, if at all. So this patch might
not be the "correct" fix of the problem. Nevertheless, it does fix the
problem.