### PR TITLE
Add option for socket permissions

### DIFF
--- a/src/lib/config/default.ts
+++ b/src/lib/config/default.ts
@@ -8,6 +8,11 @@ export const defaultConfig: Config = {
   urlPath: '',
   host: '0.0.0.0',
   port: 3000,
+  socket: {
+    group: undefined,
+    owner: undefined,
+    mode: undefined
+  },
   loglevel: 'info',
   urlAddPort: false,
   allowOrigin: ['localhost'],

--- a/src/lib/config/environment.ts
+++ b/src/lib/config/environment.ts
@@ -7,6 +7,11 @@ export const environment = {
   host: process.env.CMD_HOST,
   port: toIntegerConfig(process.env.CMD_PORT),
   path: process.env.CMD_PATH,
+  socket: {
+    group: process.env.CMD_SOCKET_GROUP,
+    owner: process.env.CMD_SOCKET_OWNER,
+    mode: process.env.CMD_SOCKET_MODE
+  },
   loglevel: process.env.CMD_LOGLEVEL,
   urlAddPort: toBooleanConfig(process.env.CMD_URL_ADDPORT),
   useSSL: toBooleanConfig(process.env.CMD_USESSL),


### PR DESCRIPTION
This allows configuring the group and mode of the unix socket after it
has been created to allow reverse proxies to access it. Fixes #317.

I decided to call `chown` and `chgrp` directly to change the owner and
group (the former will almost definitely not be called; only root can
chown a file to another user, and you are not running codimd as root. It
is included for consistency).

The nodejs chown/chgrp functions only accepts uid and gid, not the names
of the user or group. The standard way to convert a group name into a gid
is the `uid-number` package. The way this package works is that

1. It spawns a new nodejs process
2. The new nodejs process calls nodejs' setgid function, which *does*
   accept both the group name and gid
3. It then calls getuid to retrieve the uid of the process, and returns
   it to the parent process via stdout.

While this *works*, it is hacky, and if we are spawning a process
anyway, might as well call `chgrp` directly.

This does not update the documentation because we are merging into
release/2.0.x but master reworks the configuration section of the
documentation, so there will be a conflict when we merge anyway.