### PR TITLE
Fix yaml-metadata docs example for lang

### DIFF
--- a/public/docs/yaml-metadata.md
+++ b/public/docs/yaml-metadata.md
@@ -77,7 +77,7 @@ https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 
 **Example**
 ```yml
-langs: ja-jp
+lang: ja-jp
 ```
 
 dir


### PR DESCRIPTION
In the yaml-metadata docs, the example for the 'lang' attribute had an invalid key 'langs'.