### PR TITLE
Fix dmpWorker logging

### DIFF
--- a/src/lib/models/revision.ts
+++ b/src/lib/models/revision.ts
@@ -21,6 +21,7 @@ class Data {
   cacheKey
   error
   result
+  level
 }
 
 function createDmpWorker (): ChildProcess {
@@ -33,6 +34,10 @@ function createDmpWorker (): ChildProcess {
     }
     const cacheKey = data.cacheKey
     switch (data.msg) {
+      case 'log':
+        logger.log(data.level, data.result[0], ...data.result[1])
+        // The cacheKey is a dummy value and we want to skip the delete line.
+        return
       case 'error':
         dmpCallbackCache[cacheKey](data.error, null)
         break


### PR DESCRIPTION
dmpWorker is run as a childProcess, which is a completely separate
nodejs instance. As such, the `logger` it obtains is a separate instance
than the one in the parent. The parent reads the config file to
determine the log level, but the childProcess does not. So the log level
used in dmpWorker is always `debug`, regardless of the configuration
options.

In addition to polluting the logs, this is potentially a privacy issue,
because `dmpWorker` logs the diffs of notes at the `debug` level, which
will then enter the system logs.

This commit fixes this by making `dmpWorker` send any messages back to
the parent, who is responsible for logging. This also avoids any
potential race conditions between the two loggers writing to the same
output.

Fixes #433