### PR TITLE
Set lang-metadata from yaml as document language

### DIFF
--- a/lib/models/note.js
+++ b/lib/models/note.js
@@ -406,6 +406,7 @@ module.exports = function (sequelize, DataTypes) {
       if (meta.title && (typeof meta.title === 'string' || typeof meta.title === 'number')) { _meta.title = meta.title }
       if (meta.description && (typeof meta.description === 'string' || typeof meta.description === 'number')) { _meta.description = meta.description }
       if (meta.robots && (typeof meta.robots === 'string' || typeof meta.robots === 'number')) { _meta.robots = meta.robots }
+      if (meta.lang && (typeof meta.lang === 'string')) { _meta.lang = meta.lang }
       if (meta.GA && (typeof meta.GA === 'string' || typeof meta.GA === 'number')) { _meta.GA = meta.GA }
       if (meta.disqus && (typeof meta.disqus === 'string' || typeof meta.disqus === 'number')) { _meta.disqus = meta.disqus }
       if (meta.slideOptions && (typeof meta.slideOptions === 'object')) { _meta.slideOptions = meta.slideOptions }

--- a/lib/web/note/util.js
+++ b/lib/web/note/util.js
@@ -81,6 +81,7 @@ exports.getPublishData = function (req, res, note, callback) {
   const data = {
     title: title,
     description: meta.description || (markdown ? models.Note.generateDescription(markdown) : null),
+    lang: meta.lang || null
     viewcount: note.viewcount,
     createtime: createtime,
     updatetime: updatetime,

--- a/lib/web/note/util.js
+++ b/lib/web/note/util.js
@@ -81,7 +81,7 @@ exports.getPublishData = function (req, res, note, callback) {
   const data = {
     title: title,
     description: meta.description || (markdown ? models.Note.generateDescription(markdown) : null),
-    lang: meta.lang || null
+    lang: meta.lang || null,
     viewcount: note.viewcount,
     createtime: createtime,
     updatetime: updatetime,

--- a/public/views/pretty.ejs
+++ b/public/views/pretty.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="<%= lang || "en" %>">
 
 <head>
     <meta charset="utf-8">


### PR DESCRIPTION
This PR fixes the problem that published CodiMD notes have a hardcoded `lang=en` html-attribute and therefore won't be correctly identified by external parsers or translation browser extensions.
If you set the `lang` [yaml-metadata](https://demo.codimd.org/yaml-metadata#lang), that value will be used instead of 'en' with this PR.