### PR TITLE
[1.x] Fix dropbox import/export buttons not working

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -32,6 +32,10 @@ var googleAnalyticsDirectives = {
   scriptSrc: ['https://www.google-analytics.com']
 }
 
+var dropboxDirectives = {
+  scriptSrc: ['https://www.dropbox.com']
+}
+
 CspStrategy.computeDirectives = function () {
   var directives = {}
   mergeDirectives(directives, config.csp.directives)
@@ -39,6 +43,7 @@ CspStrategy.computeDirectives = function () {
   mergeDirectivesIf(config.useCDN, directives, cdnDirectives)
   mergeDirectivesIf(config.csp.addDisqus, directives, disqusDirectives)
   mergeDirectivesIf(config.csp.addGoogleAnalytics, directives, googleAnalyticsDirectives)
+  mergeDirectivesIf(config.dropbox.appKey, directives, dropboxDirectives)
   if (!areAllInlineScriptsAllowed(directives)) {
     addInlineScriptExceptions(directives)
   }

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -33,7 +33,7 @@ var googleAnalyticsDirectives = {
 }
 
 var dropboxDirectives = {
-  scriptSrc: ['https://www.dropbox.com']
+  scriptSrc: ['https://www.dropbox.com', '\'unsafe-inline\'']
 }
 
 CspStrategy.computeDirectives = function () {

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -996,7 +996,8 @@ ui.toolbar.export.snippet.click(function () {
     })
 })
 // import from dropbox
-ui.toolbar.import.dropbox.click(function () {
+ui.toolbar.import.dropbox.click(function (event) {
+  event.preventDefault()
   var options = {
     success: function (files) {
       ui.spinner.show()

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -944,7 +944,8 @@ ui.toolbar.download.rawhtml.click(function (e) {
 // pdf
 ui.toolbar.download.pdf.attr('download', '').attr('href', noteurl + '/pdf')
 // export to dropbox
-ui.toolbar.export.dropbox.click(function () {
+ui.toolbar.export.dropbox.click(function (event) {
+  event.preventDefault()
   var filename = renderFilename(ui.area.markdown) + '.md'
   var options = {
     files: [

--- a/test/csp.js
+++ b/test/csp.js
@@ -27,7 +27,10 @@ describe('Content security policies', function () {
         upgradeInsecureRequests: 'auto',
         reportURI: undefined
       },
-      useCDN: true
+      useCDN: true,
+      dropbox: {
+        appKey: undefined
+      }
     }
   })
 

--- a/test/csp.js
+++ b/test/csp.js
@@ -81,6 +81,16 @@ describe('Content security policies', function () {
     assert(!csp.computeDirectives().fontSrc.includes('https://*.disquscdn.com'))
   })
 
+  it('Include dropbox if configured', function () {
+    let testconfig = defaultConfig
+    testconfig.dropbox.appKey = 'hedgedoc'
+    mock('../lib/config', testconfig)
+    csp = mock.reRequire('../lib/csp')
+
+    assert(csp.computeDirectives().scriptSrc.includes('https://www.dropbox.com'))
+    assert(csp.computeDirectives().scriptSrc.includes('\'unsafe-inline\''))
+  })
+
   it('Set ReportURI', function () {
     let testconfig = defaultConfig
     testconfig.csp.reportURI = 'https://example.com/reportURI'


### PR DESCRIPTION
The lack of a 'preventDefault' on the click event handlers resulted in the dropbox links being unclickable.
Furthermore, because of a missing CSP rule, the dropbox script couldn't be loaded. The dropbox origin is now added to the CSP script sources if dropbox integration is configured.

Fixes #484 