### PR TITLE
Makes the mime also work with upper case extension

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,7 @@ exports.isSQLite = function isSQLite (sequelize) {
 exports.getImageMimeType = function getImageMimeType (imagePath) {
   var fileExtension = /[^.]+$/.exec(imagePath)
 
-  switch (fileExtension[0]) {
+  switch (fileExtension[0].toLowerCase()) {
     case 'bmp':
       return 'image/bmp'
     case 'gif':


### PR DESCRIPTION
If you upload images like .JPG, this fails without this fix.