### PR TITLE
Fix stack trace logging

### DIFF
--- a/src/logger/nest-console-logger.service.ts
+++ b/src/logger/nest-console-logger.service.ts
@@ -13,7 +13,7 @@ export class NestConsoleLoggerService implements LoggerService {
 
   error(message: any, trace?: string, context?: string): any {
     this.consoleLoggerService.setContext(context);
-    this.consoleLoggerService.error(message);
+    this.consoleLoggerService.error(message, trace);
   }
 
   log(message: any, context?: string): any {


### PR DESCRIPTION
The current implementation of `NestConsoleLoggerService` missed propagating the stack trace to the underlying `ConsoleLoggerService`. This PR fixes this bug.