### PR TITLE
Monitoring: Source server version for status from package.json

### DIFF
--- a/src/monitoring/monitoring.service.ts
+++ b/src/monitoring/monitoring.service.ts
@@ -1,9 +1,39 @@
 import { Injectable } from '@nestjs/common';
 import { ServerStatusDto } from './server-status.dto';
+import { promises as fs } from 'fs';
+import { join as joinPath } from 'path';
+
+let versionCache: null | {
+  major: number;
+  minor: number;
+  patch: number;
+  preRelease?: string;
+  commit?: string;
+} = null;
+async function getServerVersionFromPackageJson() {
+  if (versionCache === null) {
+    const rawFileContent: string = await fs.readFile(
+      joinPath(__dirname, '../../package.json'),
+      { encoding: 'utf8' },
+    );
+    const packageInfo: { version: string } = JSON.parse(rawFileContent);
+    const versionParts: number[] = packageInfo.version
+      .split('.')
+      .map(x => parseInt(x, 10));
+    versionCache = {
+      major: versionParts[0],
+      minor: versionParts[1],
+      patch: versionParts[2],
+      preRelease: 'dev', // TODO: Replace this?
+    };
+  }
+
+  return versionCache;
+}
 
 @Injectable()
 export class MonitoringService {
-  getServerStatus(): ServerStatusDto {
+  async getServerStatus(): Promise<ServerStatusDto> {
     return {
       connectionSocketQueueLenght: 0,
       destictOnlineUsers: 0,
@@ -16,12 +46,7 @@ export class MonitoringService {
       onlineRegisteredUsers: 0,
       onlineUsers: 0,
       registeredUsers: 0,
-      serverVersion: {
-        major: 2,
-        minor: 0,
-        patch: 0,
-        preRelease: 'dev',
-      },
+      serverVersion: await getServerVersionFromPackageJson(),
     };
   }
 }


### PR DESCRIPTION
- The caching here is whacky and should be replaced with something more general in the future.
- This lacks tests.