### PR TITLE
Generic OAuth2: Set state: true

### DIFF
--- a/lib/web/auth/oauth2/index.js
+++ b/lib/web/auth/oauth2/index.js
@@ -90,7 +90,8 @@ passport.use(new OAuth2CustomStrategy({
   clientSecret: config.oauth2.clientSecret,
   callbackURL: config.serverURL + '/auth/oauth2/callback',
   userProfileURL: config.oauth2.userProfileURL,
-  scope: config.oauth2.scope
+  scope: config.oauth2.scope,
+  state: true
 }, passportGeneralCallback))
 
 oauth2Auth.get('/auth/oauth2', function (req, res, next) {


### PR DESCRIPTION
The OAuth2 specification RECOMMENDS setting the state to protect against
CSRF attacks. Some OAuth2 providers (e.g. ORY Hydra) refuse to
authenticate without the state set.

This is a cherry-pick of 852868419dc03d5dec79e75a3d7692ab670c927f.

Closes #535 