### PR TITLE
Use URL constructor instead of regex to check for valid URL

### DIFF
--- a/public/js/extra.js
+++ b/public/js/extra.js
@@ -178,16 +178,11 @@ function slugifyWithUTF8 (text) {
 }
 
 export function isValidURL (str) {
-  const pattern = new RegExp('^(https?:\\/\\/)?' + // protocol
-        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-        '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-        '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-        '(\\#[-a-z\\d_]*)?$', 'i') // fragment locator
-  if (!pattern.test(str)) {
+  try {
+    const url = new URL(str)
+    return ['http:', 'https:'].includes(url.protocol)
+  } catch (e) {
     return false
-  } else {
-    return true
   }
 }
 


### PR DESCRIPTION
Fixes #545
Basic auth-regex from https://gist.github.com/dperini/729294

Co-authored-by: Yannick Bungers <git@innay.de>
Signed-off-by: David Mehren <git@herrmehren.de>