### PR TITLE
Fix deprecation warning of "includeSubDomains"

### DIFF
--- a/app.js
+++ b/app.js
@@ -91,7 +91,7 @@ app.use(compression())
 if (config.hsts.enable) {
   app.use(helmet.hsts({
     maxAge: config.hsts.maxAgeSeconds,
-    includeSubdomains: config.hsts.includeSubdomains,
+    includeSubDomains: config.hsts.includeSubdomains,
     preload: config.hsts.preload
   }))
 } else if (config.useSSL) {


### PR DESCRIPTION
This PR fixes the HSTS deprecation warning for "includeSubdomains"
Fixes #74
