### PR TITLE
Save note title to database when creating a note

### DIFF
--- a/lib/web/note/util.js
+++ b/lib/web/note/util.js
@@ -59,7 +59,8 @@ exports.newNote = function (req, res, body) {
   models.Note.create({
     ownerId: owner,
     alias: req.alias ? req.alias : null,
-    content: body
+    content: body,
+    title: models.Note.parseNoteTitle(body)
   }).then(function (note) {
     return res.redirect(config.serverURL + '/' + (note.alias ? note.alias : models.Note.encodeNoteId(note.id)))
   }).catch(function (err) {


### PR DESCRIPTION
Currently, when creating a note with content via the API, a title is only saved to the database after visiting the note with the browser. This commit makes sure that a title is saved at creation time.

Closes #306

Signed-off-by: David Mehren <git@herrmehren.de>